### PR TITLE
Add API key security enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
 
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self';
+                 script-src 'self';
+                 style-src 'self' 'unsafe-inline';
+                 connect-src 'self' https://generativelanguage.googleapis.com;
+                 img-src 'self' data: https:;" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/ApiKeySecurityDialog.tsx
+++ b/src/components/ApiKeySecurityDialog.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+import { X, ShieldAlert, AlertTriangle } from 'lucide-react';
+import { useSettings } from '../contexts/SettingsContext';
+
+interface ApiKeySecurityDialogProps {
+    onAccept: () => void;
+    onUseCopyPaste: () => void;
+}
+
+export const ApiKeySecurityDialog = ({
+    onAccept,
+    onUseCopyPaste,
+}: ApiKeySecurityDialogProps) => {
+    const { t } = useSettings();
+    const dialogRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onUseCopyPaste();
+            }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        dialogRef.current?.focus();
+
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [onUseCopyPaste]);
+
+    return (
+        <div
+            className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in duration-200"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="security-dialog-title"
+        >
+            <div
+                ref={dialogRef}
+                tabIndex={-1}
+                className="glass-panel w-full max-w-md p-6 shadow-2xl animate-in zoom-in-95 duration-200 outline-none"
+            >
+                <div className="flex items-start justify-between mb-4">
+                    <div className="flex items-center gap-3">
+                        <div className="p-2 bg-amber-500/20 rounded-xl">
+                            <ShieldAlert className="text-amber-500" size={24} />
+                        </div>
+                        <h2 id="security-dialog-title" className="text-lg font-bold text-text-main">
+                            {t.apiKeySecurity.title}
+                        </h2>
+                    </div>
+                    <button
+                        onClick={onUseCopyPaste}
+                        className="p-1.5 hover:bg-white/50 dark:hover:bg-black/30 rounded-full transition-colors text-text-muted hover:text-text-base"
+                        aria-label="Close"
+                    >
+                        <X size={20} />
+                    </button>
+                </div>
+
+                <p className="text-text-base mb-4">
+                    {t.apiKeySecurity.description}
+                </p>
+
+                <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4 mb-4">
+                    <p className="text-sm font-medium text-amber-700 dark:text-amber-400 mb-2">
+                        {t.apiKeySecurity.risks}
+                    </p>
+                    <ul className="space-y-2 text-sm text-text-muted">
+                        <li className="flex items-start gap-2">
+                            <AlertTriangle className="text-amber-500 shrink-0 mt-0.5" size={14} />
+                            <span>{t.apiKeySecurity.risk1}</span>
+                        </li>
+                        <li className="flex items-start gap-2">
+                            <AlertTriangle className="text-amber-500 shrink-0 mt-0.5" size={14} />
+                            <span>{t.apiKeySecurity.risk2}</span>
+                        </li>
+                        <li className="flex items-start gap-2">
+                            <AlertTriangle className="text-amber-500 shrink-0 mt-0.5" size={14} />
+                            <span>{t.apiKeySecurity.risk3}</span>
+                        </li>
+                    </ul>
+                </div>
+
+                <p className="text-sm text-text-muted mb-6">
+                    {t.apiKeySecurity.recommendation}
+                </p>
+
+                <div className="flex flex-col gap-3">
+                    <button
+                        onClick={onAccept}
+                        className="btn bg-amber-500 hover:bg-amber-600 text-white w-full py-3 rounded-xl shadow-lg"
+                    >
+                        {t.apiKeySecurity.understand}
+                    </button>
+                    <button
+                        onClick={onUseCopyPaste}
+                        className="btn btn-primary w-full py-3 rounded-xl shadow-lg shadow-primary/20"
+                    >
+                        {t.apiKeySecurity.useCopyPaste}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/ClearApiKeyDialog.tsx
+++ b/src/components/ClearApiKeyDialog.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react';
+import { X, Key, Trash2 } from 'lucide-react';
+import { useSettings } from '../contexts/SettingsContext';
+
+interface ClearApiKeyDialogProps {
+    onClear: () => void;
+    onKeep: () => void;
+}
+
+export const ClearApiKeyDialog = ({
+    onClear,
+    onKeep,
+}: ClearApiKeyDialogProps) => {
+    const { t } = useSettings();
+    const dialogRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onKeep();
+            }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        dialogRef.current?.focus();
+
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [onKeep]);
+
+    return (
+        <div
+            className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in duration-200"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="clear-api-key-dialog-title"
+        >
+            <div
+                ref={dialogRef}
+                tabIndex={-1}
+                className="glass-panel w-full max-w-sm p-6 shadow-2xl animate-in zoom-in-95 duration-200 outline-none"
+            >
+                <div className="flex items-start justify-between mb-4">
+                    <div className="flex items-center gap-3">
+                        <div className="p-2 bg-primary/20 rounded-xl">
+                            <Key className="text-primary" size={24} />
+                        </div>
+                        <h2 id="clear-api-key-dialog-title" className="text-lg font-bold text-text-main">
+                            {t.clearApiKey.title}
+                        </h2>
+                    </div>
+                    <button
+                        onClick={onKeep}
+                        className="p-1.5 hover:bg-white/50 dark:hover:bg-black/30 rounded-full transition-colors text-text-muted hover:text-text-base"
+                        aria-label="Close"
+                    >
+                        <X size={20} />
+                    </button>
+                </div>
+
+                <p className="text-text-muted mb-6">
+                    {t.clearApiKey.description}
+                </p>
+
+                <div className="flex flex-col gap-3">
+                    <button
+                        onClick={onClear}
+                        className="btn bg-red-500 hover:bg-red-600 text-white w-full py-3 rounded-xl shadow-lg flex items-center justify-center gap-2"
+                    >
+                        <Trash2 size={18} />
+                        {t.clearApiKey.clear}
+                    </button>
+                    <button
+                        onClick={onKeep}
+                        className="btn bg-white/50 hover:bg-white/70 dark:bg-black/30 dark:hover:bg-black/40 text-text-main w-full py-3 rounded-xl border border-[var(--glass-border)]"
+                    >
+                        {t.clearApiKey.keep}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/WelcomeDialog.tsx
+++ b/src/components/WelcomeDialog.tsx
@@ -59,13 +59,13 @@ export const WelcomeDialog: React.FC<WelcomeDialogProps> = ({ onClose }) => {
                     </div>
 
                     <div className="flex gap-3">
-                        <Key className="text-secondary shrink-0 mt-0.5" size={20} />
-                        <p className="text-sm text-text-muted">{t.welcome.apiKey}</p>
+                        <ClipboardCopy className="text-secondary shrink-0 mt-0.5" size={20} />
+                        <p className="text-sm text-text-muted">{t.welcome.copyPasteMode}</p>
                     </div>
 
                     <div className="flex gap-3">
-                        <ClipboardCopy className="text-secondary shrink-0 mt-0.5" size={20} />
-                        <p className="text-sm text-text-muted">{t.welcome.copyPasteMode}</p>
+                        <Key className="text-secondary shrink-0 mt-0.5" size={20} />
+                        <p className="text-sm text-text-muted">{t.welcome.apiKey}</p>
                     </div>
 
                     <div className="flex gap-3">

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,6 +9,7 @@
 export const STORAGE_KEYS = {
     API_KEY: 'gemini_api_key',
     USE_COPY_PASTE: 'use_copy_paste',
+    API_KEY_WARNING_SEEN: 'api_key_warning_seen',
     SPICE_RACK: 'spice_rack_items',
     PEOPLE_COUNT: 'people_count',
     MEALS_COUNT: 'meals_count',

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -72,8 +72,8 @@ export const translations = {
             pantry: "Add your available ingredients to the Pantry. The AI will try to use all of them in your recipes.",
             spiceRack: "The Spice Rack stores staples like spices and oils that you always have on hand.",
             settings: "Choose your diet preference, number of people, and how many meals to plan.",
-            apiKey: "You'll need a Gemini API key to generate recipes. Get one at Google AI Studio.",
-            copyPasteMode: "Alternatively, use Copy & Paste mode to work with any AI chat (ChatGPT, Claude, etc.) without an API key.",
+            copyPasteMode: "Use Copy & Paste mode (default) to work with any AI chat (ChatGPT, Claude, Gemini, etc.) without storing credentials.",
+            apiKey: "Alternatively, you can use a Gemini API key for a more streamlined experience. Get one at Google AI Studio.",
             generates: "Hit 'Generate' and the AI will create personalized recipes with a consolidated shopping list.",
             localStorage: "Your settings and recipes are saved in your browser's local storage. If you clear your browser data, this information will be lost.",
             dontShowAgain: "Don't show this again",
@@ -101,6 +101,23 @@ export const translations = {
             instructionsPasteEnd: "right below the AI's response.",
             responsePlaceholder: "Paste the exact AI response here...",
             responseRequired: "Please paste the AI's response first."
+        },
+        apiKeySecurity: {
+            title: "API Key Storage Notice",
+            description: "Your API key will be stored in your browser's local storage in plain text.",
+            risks: "This means:",
+            risk1: "Anyone with access to this device can view your API key",
+            risk2: "Browser extensions may be able to read it",
+            risk3: "The key persists until you clear browser data",
+            recommendation: "For better security, consider using Copy & Paste mode instead, which doesn't store any credentials.",
+            understand: "I understand, continue",
+            useCopyPaste: "Use Copy & Paste instead"
+        },
+        clearApiKey: {
+            title: "Clear API Key?",
+            description: "Do you want to remove your stored API key from this device?",
+            clear: "Yes, clear it",
+            keep: "No, keep it"
         }
     },
     German: {
@@ -175,8 +192,8 @@ export const translations = {
             pantry: "Füge deine verfügbaren Zutaten zum Vorratsschrank hinzu. Die KI versucht, alle davon zu verwenden.",
             spiceRack: "Das Gewürzregal speichert Grundvorräte wie Gewürze und Öle, die du immer da hast.",
             settings: "Wähle deine Ernährungsvorlieben, Personenanzahl und wie viele Mahlzeiten geplant werden sollen.",
-            apiKey: "Du benötigst einen Gemini API-Schlüssel. Hole dir einen bei Google AI Studio.",
-            copyPasteMode: "Alternativ kannst du den Kopieren & Einfügen-Modus nutzen, um mit jedem KI-Chat (ChatGPT, Claude, etc.) ohne API-Schlüssel zu arbeiten.",
+            copyPasteMode: "Nutze den Kopieren & Einfügen-Modus (Standard), um mit jedem KI-Chat (ChatGPT, Claude, Gemini, etc.) ohne gespeicherte Zugangsdaten zu arbeiten.",
+            apiKey: "Alternativ kannst du einen Gemini API-Schlüssel für ein nahtloseres Erlebnis verwenden. Hole dir einen bei Google AI Studio.",
             generates: "Drücke 'Planen' und die KI erstellt personalisierte Rezepte mit einer zusammengefassten Einkaufsliste.",
             localStorage: "Deine Einstellungen und Rezepte werden im lokalen Speicher deines Browsers gespeichert. Wenn du deine Browserdaten löschst, gehen diese Informationen verloren.",
             dontShowAgain: "Nicht mehr anzeigen",
@@ -204,6 +221,23 @@ export const translations = {
             instructionsPasteEnd: "direkt unter der Antwort der KI.",
             responsePlaceholder: "Füge hier die exakte Antwort der KI ein...",
             responseRequired: "Bitte füge zuerst die Antwort der KI ein."
+        },
+        apiKeySecurity: {
+            title: "Hinweis zur API-Schlüssel-Speicherung",
+            description: "Dein API-Schlüssel wird im lokalen Speicher deines Browsers als Klartext gespeichert.",
+            risks: "Das bedeutet:",
+            risk1: "Jeder mit Zugang zu diesem Gerät kann deinen API-Schlüssel einsehen",
+            risk2: "Browser-Erweiterungen können ihn möglicherweise auslesen",
+            risk3: "Der Schlüssel bleibt gespeichert, bis du die Browserdaten löschst",
+            recommendation: "Für mehr Sicherheit empfehlen wir den Kopieren & Einfügen-Modus, der keine Zugangsdaten speichert.",
+            understand: "Verstanden, fortfahren",
+            useCopyPaste: "Kopieren & Einfügen verwenden"
+        },
+        clearApiKey: {
+            title: "API-Schlüssel löschen?",
+            description: "Möchtest du deinen gespeicherten API-Schlüssel von diesem Gerät entfernen?",
+            clear: "Ja, löschen",
+            keep: "Nein, behalten"
         }
     },
     French: {
@@ -278,8 +312,8 @@ export const translations = {
             pantry: "Ajoutez vos ingrédients disponibles au garde-manger. L'IA essaiera de tous les utiliser.",
             spiceRack: "Le rack à épices stocke les produits de base comme les épices et huiles que vous avez toujours.",
             settings: "Choisissez vos préférences alimentaires, le nombre de personnes et de repas à planifier.",
-            apiKey: "Vous aurez besoin d'une clé API Gemini. Obtenez-en une sur Google AI Studio.",
-            copyPasteMode: "Sinon, utilisez le mode Copier-Coller pour travailler avec n'importe quel chat IA (ChatGPT, Claude, etc.) sans clé API.",
+            copyPasteMode: "Utilisez le mode Copier-Coller (par défaut) pour travailler avec n'importe quel chat IA (ChatGPT, Claude, Gemini, etc.) sans stocker d'identifiants.",
+            apiKey: "Sinon, vous pouvez utiliser une clé API Gemini pour une expérience plus fluide. Obtenez-en une sur Google AI Studio.",
             generates: "Cliquez sur 'Générer' et l'IA créera des recettes personnalisées avec une liste de courses consolidée.",
             localStorage: "Vos paramètres et recettes sont sauvegardés dans le stockage local de votre navigateur. Si vous effacez vos données de navigation, ces informations seront perdues.",
             dontShowAgain: "Ne plus afficher",
@@ -307,6 +341,23 @@ export const translations = {
             instructionsPasteEnd: "juste en dessous de la réponse de l'IA.",
             responsePlaceholder: "Collez ici la réponse exacte de l'IA...",
             responseRequired: "Veuillez d'abord coller la réponse de l'IA."
+        },
+        apiKeySecurity: {
+            title: "Avis de stockage de clé API",
+            description: "Votre clé API sera stockée dans le stockage local de votre navigateur en texte clair.",
+            risks: "Cela signifie :",
+            risk1: "Toute personne ayant accès à cet appareil peut voir votre clé API",
+            risk2: "Les extensions de navigateur peuvent potentiellement la lire",
+            risk3: "La clé persiste jusqu'à ce que vous effaciez les données du navigateur",
+            recommendation: "Pour plus de sécurité, envisagez d'utiliser le mode Copier-Coller, qui ne stocke aucune information d'identification.",
+            understand: "Je comprends, continuer",
+            useCopyPaste: "Utiliser Copier-Coller"
+        },
+        clearApiKey: {
+            title: "Effacer la clé API ?",
+            description: "Voulez-vous supprimer votre clé API stockée de cet appareil ?",
+            clear: "Oui, effacer",
+            keep: "Non, conserver"
         }
     },
     Spanish: {
@@ -381,8 +432,8 @@ export const translations = {
             pantry: "Agrega tus ingredientes disponibles a la despensa. La IA intentará usar todos ellos.",
             spiceRack: "El especiero almacena productos básicos como especias y aceites que siempre tienes a mano.",
             settings: "Elige tus preferencias dietéticas, número de personas y cuántas comidas planificar.",
-            apiKey: "Necesitarás una clave API de Gemini. Obtén una en Google AI Studio.",
-            copyPasteMode: "Alternativamente, usa el modo Copiar y Pegar para trabajar con cualquier chat de IA (ChatGPT, Claude, etc.) sin clave API.",
+            copyPasteMode: "Usa el modo Copiar y Pegar (predeterminado) para trabajar con cualquier chat de IA (ChatGPT, Claude, Gemini, etc.) sin almacenar credenciales.",
+            apiKey: "Alternativamente, puedes usar una clave API de Gemini para una experiencia más fluida. Obtén una en Google AI Studio.",
             generates: "Presiona 'Generar' y la IA creará recetas personalizadas con una lista de compras consolidada.",
             localStorage: "Tus configuraciones y recetas se guardan en el almacenamiento local de tu navegador. Si borras los datos del navegador, esta información se perderá.",
             dontShowAgain: "No mostrar de nuevo",
@@ -410,6 +461,23 @@ export const translations = {
             instructionsPasteEnd: "justo debajo de la respuesta de la IA.",
             responsePlaceholder: "Pega aquí la respuesta exacta de la IA...",
             responseRequired: "Por favor, pega primero la respuesta de la IA."
+        },
+        apiKeySecurity: {
+            title: "Aviso de almacenamiento de clave API",
+            description: "Tu clave API se almacenará en el almacenamiento local de tu navegador en texto plano.",
+            risks: "Esto significa:",
+            risk1: "Cualquier persona con acceso a este dispositivo puede ver tu clave API",
+            risk2: "Las extensiones del navegador pueden leerla",
+            risk3: "La clave permanece hasta que borres los datos del navegador",
+            recommendation: "Para mayor seguridad, considera usar el modo Copiar y Pegar, que no almacena ninguna credencial.",
+            understand: "Entiendo, continuar",
+            useCopyPaste: "Usar Copiar y Pegar"
+        },
+        clearApiKey: {
+            title: "¿Eliminar clave API?",
+            description: "¿Quieres eliminar tu clave API almacenada de este dispositivo?",
+            clear: "Sí, eliminar",
+            keep: "No, mantener"
         }
     }
 };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -76,8 +76,27 @@ interface SettingsContextType {
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
 
+/**
+ * Determine the initial value for useCopyPaste mode:
+ * - Default to true (Copy & Paste mode) for new users
+ * - But if user already has an API key stored, default to false (API Key mode)
+ */
+const getInitialUseCopyPaste = (): boolean => {
+    const savedPreference = localStorage.getItem(STORAGE_KEYS.USE_COPY_PASTE);
+    if (savedPreference !== null) {
+        try {
+            return JSON.parse(savedPreference);
+        } catch {
+            // Corrupted value, fall through to default logic
+        }
+    }
+    // New user: check if they have an existing API key (from before this update)
+    const existingApiKey = localStorage.getItem(STORAGE_KEYS.API_KEY);
+    return !existingApiKey; // true (Copy & Paste) if no key, false (API Key mode) if key exists
+};
+
 export const SettingsProvider = ({ children }: { children: ReactNode }) => {
-    const [useCopyPaste, setUseCopyPaste] = useLocalStorage<boolean>(STORAGE_KEYS.USE_COPY_PASTE, false);
+    const [useCopyPaste, setUseCopyPaste] = useLocalStorage<boolean>(STORAGE_KEYS.USE_COPY_PASTE, getInitialUseCopyPaste());
     const [apiKey, setApiKey] = useStringLocalStorage(STORAGE_KEYS.API_KEY, '');
     const [people, setPeople] = useLocalStorage<number>(STORAGE_KEYS.PEOPLE_COUNT, DEFAULTS.PEOPLE_COUNT);
     const [meals, setMeals] = useLocalStorage<number>(STORAGE_KEYS.MEALS_COUNT, DEFAULTS.MEALS_COUNT);


### PR DESCRIPTION
## Summary
- Add Content Security Policy (CSP) meta tag to prevent XSS attacks
- Default new users to Copy & Paste mode (more secure, no credentials stored)
- Show security warning dialog when switching to API Key mode (every time)
- Show "Clear API Key?" dialog when switching to Copy & Paste mode (if key exists)
- Swap toggle positions: Copy & Paste (default) now on left, API Key on right
- Update welcome dialog to feature Copy & Paste mode as the recommended option
- Add translations for all new dialogs in English, German, French, and Spanish
- Add accessibility improvements (ARIA attributes, Escape key support)

## Behavior
- **New users**: Default to Copy & Paste mode
- **Existing users with API key**: Remain in API Key mode, shown security warning once on first load
- **Toggling to API Key mode**: Always shows security warning dialog
- **Toggling to Copy & Paste mode**: Asks whether to clear stored API key (if one exists)

## Test plan
- [x] New user (clear localStorage) sees Copy & Paste mode by default
- [x] Existing user with API key stays in API Key mode and sees warning once
- [x] Toggling to API Key mode shows security warning every time
- [x] Toggling to Copy & Paste mode with stored key shows clear dialog
- [x] Toggling to Copy & Paste mode without stored key switches directly
- [x] "Use Copy & Paste instead" button in warning dialog chains to clear dialog if key exists
- [x] Dialogs are centered with blurred background
- [x] Escape key closes dialogs
- [x] All translations display correctly

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)