### PR TITLE
fix: use existing error display pattern for JSON-LD schema errors

### DIFF
--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -19,6 +19,7 @@ export const translations = {
         noVeg: "No ingredients added yet.",
         apiKeyError: "Please enter a valid API Key. Get one at: https://aistudio.google.com/apikey",
         veggieError: "Please add at least one ingredient to your pantry.",
+        schemaError: "Recipe data issue detected",
         meals: "Meals to plan",
         dietOptions: {
             vegan: "Vegan",
@@ -138,6 +139,7 @@ export const translations = {
         noVeg: "Noch keine Zutaten hinzugefügt.",
         apiKeyError: "Bitte gib einen gültigen API-Key ein. Hol dir einen auf: https://aistudio.google.com/apikey",
         veggieError: "Bitte füge mindestens eine Zutat zu deinem Vorrat hinzu.",
+        schemaError: "Rezeptdatenproblem festgestellt",
         meals: "Anzahl Mahlzeiten",
         dietOptions: {
             vegan: "Vegan",
@@ -257,6 +259,7 @@ export const translations = {
         noVeg: "Aucun ingrédient ajouté pour le moment.",
         apiKeyError: "Veuillez entrer une clé API valide. Obtenez-en une sur : https://aistudio.google.com/apikey",
         veggieError: "Veuillez ajouter au moins un ingrédient à votre garde-manger.",
+        schemaError: "Problème de données de recette détecté",
         meals: "Repas à planifier",
         dietOptions: {
             vegan: "Végétalien",
@@ -376,6 +379,7 @@ export const translations = {
         noVeg: "No se han agregado ingredientes todavía.",
         apiKeyError: "Por favor ingresa una clave API válida. Obtén una en: https://aistudio.google.com/apikey",
         veggieError: "Por favor agrega al menos un ingrediente a tu despensa.",
+        schemaError: "Problema con datos de receta detectado",
         meals: "Comidas a planificar",
         dietOptions: {
             vegan: "Vegano",


### PR DESCRIPTION
Fixes #7

### Summary
Refactored the JSON-LD schema error handling in RecipeCard to use the existing error display pattern from SettingsPanel, ensuring consistent error UX across the application.

### Changes
- Wrapped schema generation in try-catch to prevent crashes
- Added user-facing error message using existing error styling from SettingsPanel
- Added schemaError translation key to all 4 languages (EN, DE, FR, ES)
- Schema script tag conditionally rendered only on success
- Console error logging maintained for debugging
- All linting checks pass

### Impact
- Single malformed recipe no longer crashes entire recipe list
- Error display matches existing app patterns (consistent UX)
- All other recipes continue to render normally

Generated with [Claude Code](https://claude.ai/code)