### PR TITLE
feat: Add comprehensive focus management to all dialogs

### DIFF
--- a/src/components/ApiKeySecurityDialog.tsx
+++ b/src/components/ApiKeySecurityDialog.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react';
 import { X, ShieldAlert, AlertTriangle } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface ApiKeySecurityDialogProps {
     onAccept: () => void;
@@ -12,19 +12,7 @@ export const ApiKeySecurityDialog = ({
     onUseCopyPaste,
 }: ApiKeySecurityDialogProps) => {
     const { t } = useSettings();
-    const dialogRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                onUseCopyPaste();
-            }
-        };
-        document.addEventListener('keydown', handleKeyDown);
-        dialogRef.current?.focus();
-
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [onUseCopyPaste]);
+    const dialogRef = useFocusTrap(onUseCopyPaste);
 
     return (
         <div

--- a/src/components/ClearApiKeyDialog.tsx
+++ b/src/components/ClearApiKeyDialog.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react';
 import { X, Key, Trash2 } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface ClearApiKeyDialogProps {
     onClear: () => void;
@@ -12,19 +12,7 @@ export const ClearApiKeyDialog = ({
     onKeep,
 }: ClearApiKeyDialogProps) => {
     const { t } = useSettings();
-    const dialogRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                onKeep();
-            }
-        };
-        document.addEventListener('keydown', handleKeyDown);
-        dialogRef.current?.focus();
-
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [onKeep]);
+    const dialogRef = useFocusTrap(onKeep);
 
     return (
         <div

--- a/src/components/CopyPasteDialog.tsx
+++ b/src/components/CopyPasteDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import { X, Copy, Check, AlertCircle } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface CopyPasteDialogProps {
     prompt: string;
@@ -21,6 +22,7 @@ export const CopyPasteDialog: React.FC<CopyPasteDialogProps> = ({
     const [response, setResponse] = useState('');
     const [error, setError] = useState<string | null>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const dialogRef = useFocusTrap(onCancel);
 
     const handleCopyAndProceed = async () => {
         try {
@@ -53,11 +55,20 @@ export const CopyPasteDialog: React.FC<CopyPasteDialogProps> = ({
     };
 
     return (
-        <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in duration-200">
-            <div className="glass-panel w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col shadow-2xl animate-in zoom-in-95 duration-200">
+        <div
+            className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in duration-200"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="copy-paste-dialog-title"
+        >
+            <div
+                ref={dialogRef}
+                tabIndex={-1}
+                className="glass-panel w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col shadow-2xl animate-in zoom-in-95 duration-200 outline-none"
+            >
                 {/* Header */}
                 <div className="flex items-center justify-between p-3 border-b border-border-base/30">
-                    <h2 className="text-xl font-bold bg-gradient-to-r from-primary to-secondary text-transparent bg-clip-text">
+                    <h2 id="copy-paste-dialog-title" className="text-xl font-bold bg-gradient-to-r from-primary to-secondary text-transparent bg-clip-text">
                         {t.copyPaste.title}
                     </h2>
                     <button

--- a/src/components/WelcomeDialog.tsx
+++ b/src/components/WelcomeDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { X, Refrigerator, Leaf, Utensils, Key, ClipboardCopy, Sparkles, HardDrive } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { STORAGE_KEYS } from '../constants';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface WelcomeDialogProps {
     onClose: () => void;
@@ -12,6 +13,7 @@ export const WelcomeDialog: React.FC<WelcomeDialogProps> = ({ onClose }) => {
     const [dontShowAgain, setDontShowAgain] = useState(() => {
         return localStorage.getItem(STORAGE_KEYS.WELCOME_DISMISSED) === 'true';
     });
+    const dialogRef = useFocusTrap(onClose);
 
     const handleClose = () => {
         if (dontShowAgain) {
@@ -23,10 +25,19 @@ export const WelcomeDialog: React.FC<WelcomeDialogProps> = ({ onClose }) => {
     };
 
     return (
-        <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in duration-200">
-            <div className="glass-panel w-full max-w-lg max-h-[90vh] overflow-y-auto p-6 shadow-2xl animate-in zoom-in-95 duration-200">
+        <div
+            className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in duration-200"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="welcome-dialog-title"
+        >
+            <div
+                ref={dialogRef}
+                tabIndex={-1}
+                className="glass-panel w-full max-w-lg max-h-[90vh] overflow-y-auto p-6 shadow-2xl animate-in zoom-in-95 duration-200 outline-none"
+            >
                 <div className="flex items-start justify-between mb-4">
-                    <h2 className="text-xl font-bold bg-gradient-to-r from-primary to-secondary text-transparent bg-clip-text">
+                    <h2 id="welcome-dialog-title" className="text-xl font-bold bg-gradient-to-r from-primary to-secondary text-transparent bg-clip-text">
                         {t.welcome.title}
                     </h2>
                     <button

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Custom hook that implements focus trap for dialogs and modals.
+ *
+ * Features:
+ * - Stores and restores focus to the previously focused element
+ * - Focuses the first focusable element on mount
+ * - Traps focus within the dialog (cycles between first and last focusable elements)
+ * - Handles Escape key to close the dialog
+ *
+ * @param onClose - Callback to close the dialog (called on Escape key)
+ * @returns ref - Ref to attach to the dialog container element
+ */
+export function useFocusTrap(onClose: () => void) {
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const previousFocusRef = useRef<HTMLElement | null>(null);
+
+    useEffect(() => {
+        // Store the currently focused element
+        previousFocusRef.current = document.activeElement as HTMLElement;
+
+        // Get all focusable elements within the dialog
+        const getFocusableElements = (): HTMLElement[] => {
+            if (!dialogRef.current) return [];
+
+            const focusableSelectors = [
+                'a[href]',
+                'button:not([disabled])',
+                'textarea:not([disabled])',
+                'input:not([disabled])',
+                'select:not([disabled])',
+                '[tabindex]:not([tabindex="-1"])',
+            ].join(',');
+
+            return Array.from(
+                dialogRef.current.querySelectorAll<HTMLElement>(focusableSelectors)
+            );
+        };
+
+        // Focus the first focusable element
+        const focusableElements = getFocusableElements();
+        if (focusableElements.length > 0) {
+            focusableElements[0].focus();
+        } else {
+            // If no focusable elements, focus the dialog itself
+            dialogRef.current?.focus();
+        }
+
+        // Handle keyboard events
+        const handleKeyDown = (e: KeyboardEvent) => {
+            // Close on Escape
+            if (e.key === 'Escape') {
+                onClose();
+                return;
+            }
+
+            // Trap focus on Tab
+            if (e.key === 'Tab') {
+                const focusableElements = getFocusableElements();
+                if (focusableElements.length === 0) return;
+
+                const firstElement = focusableElements[0];
+                const lastElement = focusableElements[focusableElements.length - 1];
+
+                if (e.shiftKey) {
+                    // Shift + Tab: moving backwards
+                    if (document.activeElement === firstElement) {
+                        e.preventDefault();
+                        lastElement.focus();
+                    }
+                } else {
+                    // Tab: moving forwards
+                    if (document.activeElement === lastElement) {
+                        e.preventDefault();
+                        firstElement.focus();
+                    }
+                }
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+
+        // Cleanup: restore focus to the previously focused element
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            previousFocusRef.current?.focus();
+        };
+    }, [onClose]);
+
+    return dialogRef;
+}


### PR DESCRIPTION
Fixes #9

### Summary
Implements comprehensive focus management for all dialogs in the application to improve accessibility for screen reader and keyboard users.

### Changes
- Created reusable `useFocusTrap` hook for dialog accessibility
- Implements focus trapping (Tab/Shift+Tab cycles within dialog)
- Stores and restores focus to triggering element on close
- Auto-focuses first interactive element on mount
- Handles Escape key to close dialogs
- Added proper ARIA attributes (role, aria-modal, aria-labelledby)
- Applied to WelcomeDialog, CopyPasteDialog, ApiKeySecurityDialog, and ClearApiKeyDialog

### Testing
Please test:
- Keyboard navigation (Tab, Shift+Tab) stays within dialog
- Escape key closes dialogs
- Focus returns to trigger element after closing
- First interactive element is focused when dialog opens
- Screen reader announces dialogs correctly

Generated with [Claude Code](https://claude.ai/code)