### PR TITLE
Switch package manager from Yarn to npm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ The prompt in `buildRecipePrompt()` has specific rules that prevent common LLM m
 - **Icons**: Lucide React
 - **LLM Provider**: Google Gemini API (`gemini-3-flash-preview`)
 - **Linting**: ESLint 9 (flat config) with TypeScript-ESLint
-- **Package Manager**: Yarn 4.5.3
+- **Package Manager**: npm
 
 ## Configuration Files
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,5 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^7.2.4"
-  },
-  "packageManager": "yarn@4.5.3+sha512.3003a14012e2987072d244c720506549c1aab73ee728208f1b2580a9fd67b92d61ba6b08fe93f6dce68fd771e3af1e59a0afa28dd242dd0940d73b95fedd4e90"
+  }
 }


### PR DESCRIPTION
## Summary
This PR removes Yarn as the project's package manager and switches to npm, which is the default Node.js package manager.

## Changes Made
- Updated `CLAUDE.md` to reflect npm as the package manager instead of Yarn 4.5.3
- Removed the `packageManager` field from `package.json` that was pinning Yarn 4.5.3

## Details
The `packageManager` field in `package.json` enforces a specific package manager version when present. By removing this constraint, the project will now use the npm version available in the user's environment, simplifying setup and reducing friction for contributors who may not have Yarn installed.

https://claude.ai/code/session_017a7ZfAzppKM9WSXbxoesj4