### PR TITLE
feat: allow github-actions[bot] to trigger Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,7 +14,7 @@ jobs:
   claude:
     if: |
       (
-        github.actor == 'DrDonik' &&
+        (github.actor == 'DrDonik' || github.actor == 'github-actions[bot]') &&
         (
           (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
           (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||


### PR DESCRIPTION
This enables the issue-validation workflow to automatically trigger
Claude for implementation when it posts an @claude comment on issues
that are safe to auto-implement from trusted actors.

https://claude.ai/code/session_01PyPajVQg1MyyTdeMKc2gyR