### PR TITLE
fix: grant write permissions to Claude workflow for implementations

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,9 +29,9 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
The workflow triggered correctly on the approved-for-auto-impl label,
but Claude couldn't implement anything because permissions were read-only.
Claude needs write access to contents, pull-requests, and issues to
push changes, create PRs, and comment on issues.

https://claude.ai/code/session_01KTcHR1wAo4bmWMvZdmx9rh