### PR TITLE
fix: add issue context and expand allowed gh commands

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,9 +51,9 @@ jobs:
             actions: read
 
           # Provide a prompt for label-triggered events (no @claude mention to parse)
-          prompt: ${{ github.event.action == 'labeled' && github.event.label.name == 'approved-for-auto-impl' && '@claude Please implement the fix/enhancement described in this issue.' || '' }}
+          prompt: ${{ github.event.action == 'labeled' && github.event.label.name == 'approved-for-auto-impl' && format('@claude Please implement the fix/enhancement described in issue #{0}: {1}', github.event.issue.number, github.event.issue.html_url) || '' }}
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh pr:*)" "Bash(npm install)" "Bash(npm run build)" "Bash(npm run lint)" "Bash(npm run test)"'
+          claude_args: '--allowed-tools "Bash(gh issue:*)" "Bash(gh pr:*)" "Bash(npm install)" "Bash(npm run build)" "Bash(npm run lint)" "Bash(npm run test)"'


### PR DESCRIPTION
- Include issue number and URL in label-triggered prompt so Claude knows which issue to implement
- Allow gh issue commands (view, comment, list, etc.) in addition to gh pr commands

https://claude.ai/code/session_01PyPajVQg1MyyTdeMKc2gyR