### PR TITLE
fix: add aria-label attributes for form inputs

### DIFF
--- a/src/components/PantryInput.tsx
+++ b/src/components/PantryInput.tsx
@@ -93,6 +93,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                 onChange={(e) => setName(e.target.value)}
                                 onKeyDown={handleNameKeyDown}
                                 className="input-field w-full"
+                                aria-label={t.placeholders.ingredient}
                             />
                         </div>
                         <div className="flex gap-2">
@@ -103,6 +104,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                 value={amount}
                                 onChange={(e) => setAmount(e.target.value)}
                                 className="input-field flex-1"
+                                aria-label={t.placeholders.amount}
                             />
                         </div>
                         <div className="flex gap-2">

--- a/src/components/SpiceRack.tsx
+++ b/src/components/SpiceRack.tsx
@@ -55,6 +55,7 @@ export const SpiceRack: React.FC<SpiceRackProps> = ({
                             value={newSpice}
                             onChange={(e) => setNewSpice(e.target.value)}
                             className="input-field w-full flex-1"
+                            aria-label={t.spicesPlaceholder}
                         />
                         <button type="submit" className="btn btn-primary whitespace-nowrap">
                             <Plus size={18} /> {t.add}


### PR DESCRIPTION
## Summary
Adds `aria-label` attributes to form inputs in PantryInput and SpiceRack components to improve accessibility for screen readers.

## Changes
- Added `aria-label` to ingredient name input in PantryInput.tsx
- Added `aria-label` to amount input in PantryInput.tsx
- Added `aria-label` to spice input in SpiceRack.tsx

All aria-labels use existing translation keys for proper internationalization.

Fixes #11

Generated with [Claude Code](https://claude.ai/code)