### PR TITLE
fix: add ARIA attributes to loading spinner for screen reader accessibility

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -160,12 +160,17 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
             <button
                 onClick={handleGenerate}
                 disabled={loading}
+                aria-busy={loading}
                 className={`btn btn-primary w-full py-4 text-lg rounded-xl shadow-lg shadow-primary/20 ${loading ? 'opacity-80 cursor-wait' : ''}`}
             >
                 {loading ? (
                     <>
-                        <span className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></span>
-                        {t.planning}
+                        <span
+                            className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"
+                            role="status"
+                            aria-label={t.planning}
+                        ></span>
+                        <span aria-live="polite">{t.planning}</span>
                     </>
                 ) : (
                     <>


### PR DESCRIPTION
Addresses issue #13 by adding proper ARIA attributes to the loading spinner in SettingsPanel.tsx.

### Changes
- Added `aria-busy` attribute to the generate button during loading state
- Added `role='status'` and `aria-label` to the loading spinner
- Wrapped planning text with `aria-live='polite'` for status announcements

Screen reader users will now be properly informed when the application is processing recipe generation.

Fixes #13

---
Generated with [Claude Code](https://claude.ai/code)