### PR TITLE
fix: remove redundant close buttons from dialogs

### DIFF
--- a/src/components/ApiKeySecurityDialog.tsx
+++ b/src/components/ApiKeySecurityDialog.tsx
@@ -1,4 +1,4 @@
-import { X, ShieldAlert, AlertTriangle } from 'lucide-react';
+import { ShieldAlert, AlertTriangle } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 
@@ -26,22 +26,13 @@ export const ApiKeySecurityDialog = ({
                 tabIndex={-1}
                 className="glass-panel w-full max-w-md p-6 shadow-2xl animate-in zoom-in-95 duration-200 outline-none"
             >
-                <div className="flex items-start justify-between mb-4">
-                    <div className="flex items-center gap-3">
-                        <div className="p-2 bg-amber-500/20 rounded-xl">
-                            <ShieldAlert className="text-amber-500" size={24} />
-                        </div>
-                        <h2 id="security-dialog-title" className="text-lg font-bold text-text-main">
-                            {t.apiKeySecurity.title}
-                        </h2>
+                <div className="flex items-center gap-3 mb-4">
+                    <div className="p-2 bg-amber-500/20 rounded-xl">
+                        <ShieldAlert className="text-amber-500" size={24} />
                     </div>
-                    <button
-                        onClick={onUseCopyPaste}
-                        className="p-1.5 hover:bg-white/50 dark:hover:bg-black/30 rounded-full transition-colors text-text-muted hover:text-text-base focus:outline-none focus:ring-2 focus:ring-primary"
-                        aria-label="Close"
-                    >
-                        <X size={20} />
-                    </button>
+                    <h2 id="security-dialog-title" className="text-lg font-bold text-text-main">
+                        {t.apiKeySecurity.title}
+                    </h2>
                 </div>
 
                 <p className="text-text-base mb-4">

--- a/src/components/ClearApiKeyDialog.tsx
+++ b/src/components/ClearApiKeyDialog.tsx
@@ -1,4 +1,4 @@
-import { X, Key, Trash2 } from 'lucide-react';
+import { Key, Trash2 } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 
@@ -26,22 +26,13 @@ export const ClearApiKeyDialog = ({
                 tabIndex={-1}
                 className="glass-panel w-full max-w-sm p-6 shadow-2xl animate-in zoom-in-95 duration-200 outline-none"
             >
-                <div className="flex items-start justify-between mb-4">
-                    <div className="flex items-center gap-3">
-                        <div className="p-2 bg-primary/20 rounded-xl">
-                            <Key className="text-primary" size={24} />
-                        </div>
-                        <h2 id="clear-api-key-dialog-title" className="text-lg font-bold text-text-main">
-                            {t.clearApiKey.title}
-                        </h2>
+                <div className="flex items-center gap-3 mb-4">
+                    <div className="p-2 bg-primary/20 rounded-xl">
+                        <Key className="text-primary" size={24} />
                     </div>
-                    <button
-                        onClick={onKeep}
-                        className="p-1.5 hover:bg-white/50 dark:hover:bg-black/30 rounded-full transition-colors text-text-muted hover:text-text-base focus:outline-none focus:ring-2 focus:ring-primary"
-                        aria-label="Close"
-                    >
-                        <X size={20} />
-                    </button>
+                    <h2 id="clear-api-key-dialog-title" className="text-lg font-bold text-text-main">
+                        {t.clearApiKey.title}
+                    </h2>
                 </div>
 
                 <p className="text-text-muted mb-6">

--- a/src/components/WelcomeDialog.tsx
+++ b/src/components/WelcomeDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { X, Refrigerator, Leaf, Utensils, Key, ClipboardCopy, Sparkles, HardDrive } from 'lucide-react';
+import { Refrigerator, Leaf, Utensils, Key, ClipboardCopy, Sparkles, HardDrive } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { STORAGE_KEYS } from '../constants';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -36,18 +36,9 @@ export const WelcomeDialog: React.FC<WelcomeDialogProps> = ({ onClose }) => {
                 tabIndex={-1}
                 className="glass-panel w-full max-w-lg max-h-[90vh] overflow-y-auto p-6 shadow-2xl animate-in zoom-in-95 duration-200 outline-none"
             >
-                <div className="flex items-start justify-between mb-4">
-                    <h2 id="welcome-dialog-title" className="text-xl font-bold bg-gradient-to-r from-primary to-secondary text-transparent bg-clip-text">
-                        {t.welcome.title}
-                    </h2>
-                    <button
-                        onClick={handleClose}
-                        className="p-1.5 hover:bg-white/50 dark:hover:bg-black/30 rounded-full transition-colors text-text-muted hover:text-text-base focus:outline-none focus:ring-2 focus:ring-primary"
-                        aria-label="Close"
-                    >
-                        <X size={20} />
-                    </button>
-                </div>
+                <h2 id="welcome-dialog-title" className="text-xl font-bold bg-gradient-to-r from-primary to-secondary text-transparent bg-clip-text mb-4">
+                    {t.welcome.title}
+                </h2>
 
                 <p className="text-text-base mb-5">
                     {t.welcome.intro}


### PR DESCRIPTION
Removes the X (close) button from WelcomeDialog, ClearApiKeyDialog, and ApiKeySecurityDialog as they are redundant with the primary action buttons. The CopyPasteDialog retains its X button as it serves a genuine cancel purpose.

All three dialogs maintain ESC key functionality via useFocusTrap hook.

Fixes #48

Generated with [Claude Code](https://claude.ai/code)