### PR TITLE
fix: capitalize default diet preference to match select options

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -51,6 +51,6 @@ export const API_CONFIG = {
 export const DEFAULTS = {
     PEOPLE_COUNT: 2,
     MEALS_COUNT: 3,
-    DIET: 'flexitarian',
+    DIET: 'Flexitarian',
     LANGUAGE: 'English',
 } as const;


### PR DESCRIPTION
Fixes #52

This PR fixes a bug where dietary preferences showed "Vegan" in the UI on clean load but passed "flexitarian" to the LLM.

### Root Cause
Case mismatch: The default value was `'flexitarian'` (lowercase) in `src/constants/index.ts:54`, but the select element in `src/components/SettingsPanel.tsx:78` expects `'Flexitarian'` (capitalized).

### Changes
- Changed `DEFAULTS.DIET` from `'flexitarian'` to `'Flexitarian'` in `src/constants/index.ts:54`

----

Generated with [Claude Code](https://claude.ai/code)