### PR TITLE
Enable automated PR creation from Claude issue resolutions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Allow repo owner, org members, collaborators, and previous contributors
-    if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
+    # Allow repo owner, org members, collaborators, previous contributors, and github-actions bot
+    if: |
+      github.actor == 'github-actions[bot]' ||
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,7 +40,8 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           
-          # Allow Claude bot to trigger this workflow (for issue-validation chaining)
-          allowed_bots: 'claude'
+          # Allow Claude bot and github-actions bot to trigger this workflow
+          # (for issue-validation and auto-PR creation chaining)
+          allowed_bots: 'claude,github-actions'
 
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,4 +60,37 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue:*)" "Bash(gh pr:*)" "Bash(npm install)" "Bash(npm run build)" "Bash(npm run lint)" "Bash(npm run test)"'
+          claude_args: |
+            --allowed-tools "Bash(gh issue:*)" "Bash(gh pr:*)" "Bash(npm install)" "Bash(npm run build)" "Bash(npm run lint)" "Bash(npm run test)"
+            --json-schema '{"type":"object","properties":{"pr_title":{"type":"string","description":"Title for the pull request if changes were made"},"pr_body":{"type":"string","description":"Description for the pull request body if changes were made"},"made_changes":{"type":"boolean","description":"Whether any code changes were committed"}},"required":["made_changes"]}'
+
+      # Create a PR if Claude made changes and this was triggered by an issue (not an existing PR)
+      - name: Create Pull Request
+        if: |
+          steps.claude.outputs.branch_name != '' &&
+          steps.claude.outputs.structured_output != '' &&
+          fromJSON(steps.claude.outputs.structured_output).made_changes == true &&
+          (
+            github.event_name == 'issues' ||
+            (github.event_name == 'issue_comment' && github.event.issue.pull_request == null)
+          )
+        env:
+          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
+        run: |
+          # Extract PR title and body from structured output
+          PR_TITLE=$(echo '${{ steps.claude.outputs.structured_output }}' | jq -r '.pr_title // "Automated PR from Claude"')
+          PR_BODY=$(echo '${{ steps.claude.outputs.structured_output }}' | jq -r '.pr_body // "Automatically implemented by Claude."')
+
+          # Get issue number for linking
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+
+          # Append issue reference to body
+          PR_BODY="${PR_BODY}
+
+          Closes #${ISSUE_NUMBER}"
+
+          # Create the pull request
+          gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --head "${{ steps.claude.outputs.branch_name }}"


### PR DESCRIPTION
## Summary
This PR enhances the Claude automation workflows to support automatic pull request creation when Claude resolves issues. It adds structured output handling and PR creation logic while expanding bot permissions.

## Key Changes

- **Updated `claude-code-review.yml`**:
  - Extended the job condition to allow `github-actions[bot]` to trigger code reviews, enabling chaining with automated workflows
  - Updated `allowed_bots` configuration to include both `claude` and `github-actions` bots for workflow triggering

- **Enhanced `claude.yml`**:
  - Added JSON schema to Claude's `claude_args` to request structured output containing:
    - `pr_title`: Custom title for generated PRs
    - `pr_body`: Custom description for generated PRs
    - `made_changes`: Boolean flag indicating if code changes were committed
  - Implemented new "Create Pull Request" step that:
    - Triggers only when Claude made changes and the workflow was initiated by an issue (not an existing PR)
    - Extracts PR title and body from Claude's structured output with sensible defaults
    - Automatically links the created PR to the originating issue using `Closes #` syntax
    - Uses the branch created by Claude to open the PR

## Implementation Details

The PR creation logic intelligently filters on event type to avoid creating duplicate PRs when triggered by issue comments on existing pull requests. The structured output schema ensures Claude provides the necessary metadata for professional PR creation while maintaining backward compatibility through default values.

https://claude.ai/code/session_01FQvD1p3foYyQDigdh3Jdmd