### PR TITLE
Add API key storage warning indicator in Copy & Paste mode

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink } from 'lucide-react';
+import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { API_CONFIG, STORAGE_KEYS } from '../constants';
 import { ApiKeySecurityDialog } from './ApiKeySecurityDialog';
 import { ClearApiKeyDialog } from './ClearApiKeyDialog';
+import { TooltipButton } from './ui/TooltipButton';
 import type { Notification } from '../types';
 
 interface HeaderProps {
@@ -134,6 +135,16 @@ export const Header: React.FC<HeaderProps> = ({
                             AI Recipe Planner
                         </h1>
 
+                        {/* API Key Warning Indicator (when minimized) */}
+                        {headerMinimized && useCopyPaste && apiKey && (
+                            <TooltipButton
+                                icon={<AlertTriangle size={16} className="text-red-500" />}
+                                tooltip={t.apiKeyStoredWarning}
+                                ariaLabel={t.apiKeyStoredWarning}
+                                className="!p-1"
+                            />
+                        )}
+
                         {/* Toggle Button */}
                         <button
                             onClick={() => setHeaderMinimized(!headerMinimized)}
@@ -174,9 +185,20 @@ export const Header: React.FC<HeaderProps> = ({
                                         className={`absolute top-0.5 w-5 h-5 bg-primary rounded-full shadow-md transition-all duration-200 ${useCopyPaste ? 'left-0.5' : 'left-6'}`}
                                     />
                                 </button>
-                                <span className={`text-sm transition-colors ${!useCopyPaste ? 'text-text-main font-medium' : 'text-text-muted'}`}>
-                                    {t.modeSwitch.apiKey}
-                                </span>
+                                <div className="flex items-center gap-1">
+                                    <span className={`text-sm transition-colors ${!useCopyPaste ? 'text-text-main font-medium' : 'text-text-muted'}`}>
+                                        {t.modeSwitch.apiKey}
+                                    </span>
+                                    {/* API Key Warning Indicator (when expanded) */}
+                                    {useCopyPaste && apiKey && (
+                                        <TooltipButton
+                                            icon={<AlertTriangle size={16} className="text-red-500" />}
+                                            tooltip={t.apiKeyStoredWarning}
+                                            ariaLabel={t.apiKeyStoredWarning}
+                                            className="!p-1"
+                                        />
+                                    )}
+                                </div>
                             </div>
 
                             {!useCopyPaste && (

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -139,7 +139,8 @@ export const translations = {
             recipeDeleted: "Recipe deleted",
             apiKeyCleared: "API key cleared",
             action: "Undo"
-        }
+        },
+        apiKeyStoredWarning: "API key stored in local storage"
     },
     German: {
         ingredients: "Zutaten",
@@ -280,7 +281,8 @@ export const translations = {
             recipeDeleted: "Rezept gelöscht",
             apiKeyCleared: "API-Schlüssel gelöscht",
             action: "Rückgängig"
-        }
+        },
+        apiKeyStoredWarning: "API-Schlüssel im lokalen Speicher gespeichert"
     },
     French: {
         ingredients: "Ingrédients",
@@ -421,7 +423,8 @@ export const translations = {
             recipeDeleted: "Recette supprimée",
             apiKeyCleared: "Clé API effacée",
             action: "Annuler"
-        }
+        },
+        apiKeyStoredWarning: "Clé API stockée dans le stockage local"
     },
     Spanish: {
         ingredients: "Ingredientes",
@@ -562,6 +565,7 @@ export const translations = {
             recipeDeleted: "Receta eliminada",
             apiKeyCleared: "Clave API eliminada",
             action: "Deshacer"
-        }
+        },
+        apiKeyStoredWarning: "Clave API almacenada en almacenamiento local"
     }
 };


### PR DESCRIPTION
## Summary

Adds a visual security indicator when an API key remains stored in localStorage while in Copy & Paste mode.

## Changes

- Adds a red AlertTriangle icon next to "API key" text in the mode toggle section
- When header is collapsed, indicator appears between title and chevron
- Added `apiKeyStoredWarning` translation key in all 4 languages
- Uses TooltipButton component for consistent UX
- Follows existing UI patterns (same style as info tooltips)

## Condition

Indicator appears when: `useCopyPaste === true && apiKey !== ''`

Fixes #58

🤖 Generated with [Claude Code](https://claude.ai/code)