### PR TITLE
fix: use GITHUB_TOKEN instead of claude action output for PR creation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -75,7 +75,7 @@ jobs:
             (github.event_name == 'issue_comment' && github.event.issue.pull_request == null)
           )
         env:
-          GH_TOKEN: ${{ steps.claude.outputs.github_token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Extract PR title and body from structured output
           PR_TITLE=$(echo '${{ steps.claude.outputs.structured_output }}' | jq -r '.pr_title // "Automated PR from Claude"')


### PR DESCRIPTION
The github_token output from claude-code-action is not valid for use in subsequent workflow steps. Using secrets.GITHUB_TOKEN instead, which already has pull-requests: write permission.

https://claude.ai/code/session_01FQvD1p3foYyQDigdh3Jdmd