### PR TITLE
feat: make API key warning indicator clickable

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -141,7 +141,8 @@ export const Header: React.FC<HeaderProps> = ({
                                 icon={<AlertTriangle size={16} className="text-red-500" />}
                                 tooltip={t.apiKeyStoredWarning}
                                 ariaLabel={t.apiKeyStoredWarning}
-                                className="!p-1"
+                                className="!p-1 cursor-pointer hover:opacity-80 transition-opacity"
+                                onClick={() => setShowClearDialog(true)}
                             />
                         )}
 
@@ -195,7 +196,8 @@ export const Header: React.FC<HeaderProps> = ({
                                             icon={<AlertTriangle size={16} className="text-red-500" />}
                                             tooltip={t.apiKeyStoredWarning}
                                             ariaLabel={t.apiKeyStoredWarning}
-                                            className="!p-1"
+                                            className="!p-1 cursor-pointer hover:opacity-80 transition-opacity"
+                                            onClick={() => setShowClearDialog(true)}
                                         />
                                     )}
                                 </div>


### PR DESCRIPTION
Closes #61

This PR implements a UX enhancement that makes the API key warning indicator clickable to directly open the Clear API Key Dialog.

### Changes
- Add onClick handler to both warning indicators (minimized and expanded views)
- Add cursor-pointer and hover styles to indicate clickability
- Reduces clearing stored API key from 4+ clicks to 1 click
- Aligns with project's 'minimize clicks' UX philosophy

Generated with [Claude Code](https://claude.ai/code)