### PR TITLE
fix: delay recipe 2-column layout to xl breakpoint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -399,7 +399,7 @@ function App() {
                       {t.menuTitle}
                     </span>
                   </h2>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+                  <div className="grid grid-cols-1 xl:grid-cols-2 gap-10">
                     {mealPlan.recipes.map((recipe, index) => (
                       <RecipeCard
                         key={recipe.id}


### PR DESCRIPTION
Recipe cards were becoming too narrow (340px) when the viewport was
between 1024-1279px because the md breakpoint (768px) triggered
2-column layout even though the container only had ~680px width.

Changed from md:grid-cols-2 to xl:grid-cols-2 so recipe cards only
split into 2 columns at 1280px+, giving each card ~425px minimum width.

https://claude.ai/code/session_0114mP1y7Lw4gis8fY6HMB3H