### PR TITLE
fix: add divider between input and results sections on narrow viewport

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -384,6 +384,9 @@ function App() {
           </div>
 
           <div className="lg:col-span-2 space-y-8">
+            {/* Divider between input and results sections - narrow viewport only */}
+            <hr className="lg:hidden border-t-2 border-primary/30 -mt-4" />
+
             {mealPlan ? (
               <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
                 <ShoppingList


### PR DESCRIPTION
In single-column layout (< 1024px), the SpiceRack and ShoppingList panels appeared adjacent without visual distinction, making the layout difficult to parse.

Added a horizontal divider that only appears on narrow viewports (hidden at lg breakpoint and above) to clearly separate the input section (settings, pantry, spices) from the results section (shopping list, recipes).

https://claude.ai/code/session_0114mP1y7Lw4gis8fY6HMB3H