### PR TITLE
fix: open shopping list in same window instead of new tab

### DIFF
--- a/src/components/ShoppingList.tsx
+++ b/src/components/ShoppingList.tsx
@@ -185,15 +185,16 @@ export const ShoppingList: React.FC<ShoppingListProps> = ({ items, isMinimized =
                 )}
                 <div className="flex gap-2">
                     {!isStandaloneView && (
-                        <a
-                            href={shareUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                        <button
+                            onClick={() => {
+                                window.history.pushState({}, '', shareUrl);
+                                window.location.href = shareUrl;
+                            }}
                             className="p-2 bg-white/50 hover:bg-white/80 dark:bg-black/20 dark:hover:bg-black/40 rounded-full transition-colors focus:opacity-100 flex items-center justify-center text-text-muted hover:text-primary"
                             aria-label={t.openInNewTab}
                         >
                             <ExternalLink size={18} />
-                        </a>
+                        </button>
                     )}
                     {onToggleMinimize && (
                         <button


### PR DESCRIPTION
Changed the shopping list share button from an anchor tag with `target="_blank"` to a button that uses `window.history.pushState()` and `window.location.href` to navigate in the same window while updating the URL. This matches the solution implemented for recipes in issue #55 and provides a better UX by eliminating unnecessary tab management.

Fixes #66

🤖 Generated with [Claude Code](https://claude.ai/code)