### PR TITLE
Fix claude-code-review workflow tool permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,9 +40,13 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          
+
           # Allow Claude bot and github-actions bot to trigger this workflow
           # (for issue-validation and auto-PR creation chaining)
           allowed_bots: 'claude,github-actions,drdoniks-bot,dependabot'
+
+          # Allow necessary tools for code review plugin to post PR comments
+          claude_args: |
+            --allowed-tools "Bash(gh *)" "Bash(git *)" "Bash(npm *)"
 
 


### PR DESCRIPTION
Add claude_args with --allowed-tools to allow the code-review plugin to:
- Use 'gh' commands (gh api, gh pr, etc.) to post PR comments and fetch PR data
- Use 'git' commands (git fetch, git checkout, etc.) to work with repository
- Use 'npm' commands to run builds/tests if needed

This fixes the "This command requires approval" error that was blocking
PR comment posting.

https://claude.ai/code/session_01UoDQ9mYPYVh6hjJrh1KL2N