### PR TITLE
fix: use colon syntax for git/npm allowed-tools patterns in CI

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,7 +60,7 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
-            --allowed-tools "Bash(gh issue:*)" "Bash(gh pr:*)" "Bash(npm install)" "Bash(npm run build)" "Bash(npm run lint)" "Bash(npm run test)"
+            --allowed-tools "Bash(git add:*)" "Bash(git commit:*)" "Bash(git push:*)" "Bash(git status:*)" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git rm:*)" "Bash(gh issue:*)" "Bash(gh pr:*)" "Bash(npm install)" "Bash(npm run build)" "Bash(npm run lint)" "Bash(npm run test:*)" "Bash(npm test:*)"
             --json-schema '{"type":"object","properties":{"pr_title":{"type":"string","description":"Title for the pull request if changes were made"},"pr_body":{"type":"string","description":"Description for the pull request body if changes were made"},"made_changes":{"type":"boolean","description":"Whether any code changes were committed"}},"required":["made_changes"]}'
 
       - name: Generate app token for PR


### PR DESCRIPTION
The claude-code-action injects default git tool patterns using space
syntax (e.g. "Bash(git commit *)") where glob * doesn't match
newlines, causing all multi-line git commit messages to be denied.

Explicitly specify git patterns with colon syntax ("Bash(git commit:*)")
which uses prefix matching and handles multi-line commands correctly.
Also add "npm test:*" and "npm run test:*" patterns so Claude can run
tests with additional arguments.

https://claude.ai/code/session_0134Nd54UkJDTSSxxbajL46r