### PR TITLE
fix: use specific allowed tools in code review workflow for newline support

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,7 +46,9 @@ jobs:
           allowed_bots: 'claude,github-actions,drdoniks-bot'
 
           # Allow necessary tools for code review plugin to post PR comments
+          # MCP servers: list both server name (for initialization) and specific tools (for permissions)
+          # See: https://github.com/anthropics/claude-code-action/issues/723
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh api:*),Bash(gh pr:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(npm run build),Bash(npm run lint),Bash(npm test)"
+            --allowedTools "mcp__github,mcp__github__create_issue_comment,mcp__github_inline_comment,mcp__github_inline_comment__create_inline_comment,mcp__github_comment,mcp__github_comment__update_claude_comment,Bash(gh api:*),Bash(gh pr:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(npm run build),Bash(npm run lint),Bash(npm test)"
 
 


### PR DESCRIPTION
Replace broad `Bash(gh *)` pattern with specific tool permissions that
support newlines in arguments. Add `mcp__github_inline_comment__create_inline_comment`
for inline PR comments and `Bash(gh api:*)` for GraphQL queries.

The broad glob pattern `Bash(gh *)` does not allow newlines in command
arguments, which prevented the code review plugin from posting multi-line
PR comments and inline review feedback.

https://claude.ai/code/session_01CzojmJkMZN4Zgb6pFJ1xNq