### PR TITLE
fix: resolve react-hooks/set-state-in-effect violations in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,28 @@ import { useSettings } from './contexts/SettingsContext';
 import { STORAGE_KEYS, URL_PARAMS } from './constants';
 import { z } from 'zod';
 
+// Parse shared-link URL params once. Pure (no React deps) so it can feed
+// lazy useState initializers, avoiding a setState-in-effect on mount.
+function parseSharedUrlParams(): {
+  recipe: Recipe | null;
+  shoppingList: Ingredient[] | null;
+  hasInvalidData: boolean;
+} {
+  const searchParams = new URLSearchParams(window.location.search);
+  const recipeParam = searchParams.get(URL_PARAMS.RECIPE);
+  const shoppingListParam = searchParams.get(URL_PARAMS.SHOPPING_LIST);
+
+  if (recipeParam) {
+    const decoded = decodeFromUrl<Recipe>(decodeURIComponent(recipeParam), RecipeSchema);
+    return { recipe: decoded, shoppingList: null, hasInvalidData: !decoded };
+  }
+  if (shoppingListParam) {
+    const decoded = decodeFromUrl<Ingredient[]>(decodeURIComponent(shoppingListParam), z.array(IngredientSchema));
+    return { recipe: null, shoppingList: decoded, hasInvalidData: !decoded };
+  }
+  return { recipe: null, shoppingList: null, hasInvalidData: false };
+}
+
 function App() {
   const pantryInputRef = useRef<PantryInputRef>(null);
   const settingsPanelRef = useRef<SettingsPanelRef>(null);
@@ -42,8 +64,16 @@ function App() {
   const [recipeMissingIngredientsMinimized, setRecipeMissingIngredientsMinimized, recipeMissingMinPersistError] = useLocalStorage<boolean>(STORAGE_KEYS.RECIPE_MISSING_INGREDIENTS_MINIMIZED, false);
   const [mealPlan, setMealPlan, mealPlanPersistError] = useLocalStorage<MealPlan | null>(STORAGE_KEYS.MEAL_PLAN, null);
 
+  // Parse URL params once at mount. Feeds the view/notification initializers
+  // below so shared-link routing happens on the first render (no double-render).
+  const [initialSharedData] = useState(parseSharedUrlParams);
+
   const [loading, setLoading] = useState(false);
-  const [notification, setNotification] = useState<Notification | null>(null);
+  const [notification, setNotification] = useState<Notification | null>(() =>
+    initialSharedData.hasInvalidData
+      ? { message: t.invalidSharedData, type: 'error' }
+      : null
+  );
   const notificationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Welcome Dialog State
@@ -55,10 +85,10 @@ function App() {
   const [showCopyPasteDialog, setShowCopyPasteDialog] = useState(false);
   const [copyPastePrompt, setCopyPastePrompt] = useState('');
 
-  // Single Recipe View State
-  const [viewRecipe, setViewRecipe] = useState<Recipe | null>(null);
-  // Single Shopping List View State
-  const [viewShoppingList, setViewShoppingList] = useState<Ingredient[] | null>(null);
+  // Single Recipe View State (initialized from shared-link URL if present)
+  const [viewRecipe, setViewRecipe] = useState<Recipe | null>(initialSharedData.recipe);
+  // Single Shopping List View State (initialized from shared-link URL if present)
+  const [viewShoppingList, setViewShoppingList] = useState<Ingredient[] | null>(initialSharedData.shoppingList);
 
   // Wake Lock for keeping screen on during cooking
   // Note: Auto-activation was removed because Safari/iOS requires explicit user gesture
@@ -119,12 +149,19 @@ function App() {
     }
   }, [anyPersistError, showNotification, t.storageError]);
 
-  // Notify on successful pull from remote (one-shot per pull)
+  // Notify on successful pull from remote (one-shot per pull, ref-guarded like
+  // the sync-error and storage-error effects)
+  const pullNotificationShownRef = useRef(false);
   useEffect(() => {
-    if (sync.justPulledFromRemote) {
-      showNotification({ message: t.sync.pulledNotification, type: 'undo', timeout: 3000 });
-      sync.acknowledgePull();
+    if (!sync.justPulledFromRemote) {
+      pullNotificationShownRef.current = false;
+      return;
     }
+    if (pullNotificationShownRef.current) return;
+    pullNotificationShownRef.current = true;
+
+    showNotification({ message: t.sync.pulledNotification, type: 'undo', timeout: 3000 });
+    sync.acknowledgePull();
   }, [sync, showNotification, t.sync.pulledNotification]);
 
   // Surface sync errors to the user (category-specific message, one-shot per error state change)
@@ -170,38 +207,6 @@ function App() {
     prevViewRecipeRef.current = viewRecipe;
     prevViewShoppingListRef.current = viewShoppingList;
   }, [viewRecipe, viewShoppingList]);
-
-  // Ref to capture translation for URL decode effect
-  const invalidSharedDataRef = useRef(t.invalidSharedData);
-  useEffect(() => {
-    invalidSharedDataRef.current = t.invalidSharedData;
-  }, [t.invalidSharedData]);
-
-  // URL parameter decode effect - runs only once on mount
-  useEffect(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    const recipeParam = searchParams.get(URL_PARAMS.RECIPE);
-    const shoppingListParam = searchParams.get(URL_PARAMS.SHOPPING_LIST);
-
-    if (recipeParam) {
-      const decoded = decodeFromUrl<Recipe>(decodeURIComponent(recipeParam), RecipeSchema);
-      if (decoded) {
-        setViewRecipe(decoded);
-      } else {
-        // Invalid or malformed recipe data - show error
-        showNotification({ message: invalidSharedDataRef.current || "Invalid shared recipe data. The link may be corrupted.", type: 'error' });
-      }
-    } else if (shoppingListParam) {
-      const decoded = decodeFromUrl<Ingredient[]>(decodeURIComponent(shoppingListParam), z.array(IngredientSchema));
-      if (decoded) {
-        setViewShoppingList(decoded);
-      } else {
-        // Invalid or malformed shopping list data - show error
-        showNotification({ message: invalidSharedDataRef.current || "Invalid shared shopping list data. The link may be corrupted.", type: 'error' });
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Run only once on mount
 
   useEffect(() => {
     const updateMetaTags = (title: string, description: string, url: string) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,7 +71,7 @@ function App() {
   const [loading, setLoading] = useState(false);
   const [notification, setNotification] = useState<Notification | null>(() =>
     initialSharedData.hasInvalidData
-      ? { message: t.invalidSharedData, type: 'error' }
+      ? { message: t.invalidSharedData || "Invalid shared data. The link may be corrupted.", type: 'error' }
       : null
   );
   const notificationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -344,14 +344,14 @@ describe('App URL Parameter Decoding', () => {
             expect(screen.getByText('Language Test Recipe')).toBeInTheDocument();
         });
 
-        it('uses translation ref for error messages', async () => {
-            // Invalid base64 data that will trigger error
+        it('shows translated error when shared URL data is invalid', async () => {
+            // Invalid base64 data triggers the hasInvalidData branch at mount
             mockLocation.search = '?recipe=invalid-base64';
 
             renderWithSettings(<App />);
 
-            // The error message should use the translation from the ref
-            // The ref captures t.invalidSharedData and updates when it changes
+            // Notification is initialized synchronously from t.invalidSharedData
+            // via a lazy useState initializer (no setState-in-effect).
             await waitFor(() => {
                 const errorText = screen.queryByText(/Invalid shared recipe data/i) ||
                                 screen.queryByText(/The link may be corrupted/i);


### PR DESCRIPTION
## Summary

- Unblocks [#204](https://github.com/DrDonik/ai-recipe-planner/pull/204) (dependabot bump of `eslint-plugin-react-hooks` 7.0.1 → 7.1.1), whose new `react-hooks/set-state-in-effect` rule flags two patterns in `App.tsx`. Rather than suppressing, this addresses the underlying behaviour.
- URL shared-link routing now happens on the first render via lazy `useState` initializers — no more mount-time double render (home view → shared view).
- Sync-pull notification effect now uses the same ref-guard idiom as the sibling sync-error and storage-error effects.

## What changed

**`src/App.tsx`**
- New module-level `parseSharedUrlParams()` helper (pure).
- `viewRecipe`, `viewShoppingList`, and `notification` are initialised from the parsed URL via lazy `useState`. The mount-only URL decode `useEffect` is removed.
- `invalidSharedDataRef` and its translation-update effect are removed (no longer needed).
- The sync-pull notification effect gets a `pullNotificationShownRef` guard, mirroring `syncErrorShownRef` / `storageErrorShownRef`. The rule's flow analysis recognises this pattern and lets it through.

**`src/__tests__/App.test.tsx`**
- Renamed the `'uses translation ref for error messages'` case since the ref is gone — behaviour assertions unchanged.

## Why not just suppress the rule

The URL decode effect was a textbook case of what the rule is designed to catch: a one-shot routing decision run as a post-mount side effect, causing an extra render (and potential flash) before the shared view takes over. Lifting it into lazy initial state is the fix the rule is pointing at.

The sync-pull case is closer to a false positive — it's genuinely synchronising with external state — but since two sibling effects in the same file already use a ref-guard to satisfy the rule, matching that idiom is the consistent fix.

## Verification

- `npm run lint` clean against `eslint-plugin-react-hooks@7.0.1` (current) **and** `7.1.1` (verified locally via `--no-save` install; `package.json` / `package-lock.json` untouched in this PR).
- `npm test -- --run`: 390 passed, 3 skipped.
- `npm run build`: succeeds.

## Test plan

- [ ] CI lint + build + test pass.
- [ ] After merge, rebase #204 and confirm its lint check goes green.
- [ ] Smoke test a shared recipe URL (`?recipe=...`) and shared shopping list URL (`?shoppingList=...`) — confirm no flash of the home view and that invalid data still shows the error notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)