### PR TITLE
test: address PR #205 review follow-ups (parseSharedUrlParams + tighter assertions)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,37 +9,15 @@ import { KitchenAppliances, type KitchenAppliancesRef } from './components/Kitch
 import { ShoppingList } from './components/ShoppingList';
 import { WelcomeDialog } from './components/WelcomeDialog';
 import { CopyPasteDialog } from './components/CopyPasteDialog';
-import { generateRecipes, buildRecipePrompt, parseRecipeResponse, RecipeSchema, IngredientSchema } from './services/llm';
+import { generateRecipes, buildRecipePrompt, parseRecipeResponse } from './services/llm';
 import type { PantryItem, MealPlan, Recipe, Ingredient, Notification } from './types';
 import { useLocalStorage } from './hooks/useLocalStorage';
-import { decodeFromUrl, generateShareUrl } from './utils/sharing';
+import { generateShareUrl } from './utils/sharing';
+import { parseSharedUrlParams } from './utils/sharedUrlParams';
 import { Header } from './components/Header';
 import { SettingsPanel, type SettingsPanelRef } from './components/SettingsPanel';
 import { useSettings } from './contexts/SettingsContext';
 import { STORAGE_KEYS, URL_PARAMS } from './constants';
-import { z } from 'zod';
-
-// Parse shared-link URL params once. Pure (no React deps) so it can feed
-// lazy useState initializers, avoiding a setState-in-effect on mount.
-function parseSharedUrlParams(): {
-  recipe: Recipe | null;
-  shoppingList: Ingredient[] | null;
-  hasInvalidData: boolean;
-} {
-  const searchParams = new URLSearchParams(window.location.search);
-  const recipeParam = searchParams.get(URL_PARAMS.RECIPE);
-  const shoppingListParam = searchParams.get(URL_PARAMS.SHOPPING_LIST);
-
-  if (recipeParam) {
-    const decoded = decodeFromUrl<Recipe>(decodeURIComponent(recipeParam), RecipeSchema);
-    return { recipe: decoded, shoppingList: null, hasInvalidData: !decoded };
-  }
-  if (shoppingListParam) {
-    const decoded = decodeFromUrl<Ingredient[]>(decodeURIComponent(shoppingListParam), z.array(IngredientSchema));
-    return { recipe: null, shoppingList: decoded, hasInvalidData: !decoded };
-  }
-  return { recipe: null, shoppingList: null, hasInvalidData: false };
-}
 
 function App() {
   const pantryInputRef = useRef<PantryInputRef>(null);

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -8,6 +8,7 @@ import { renderWithSettings } from './testUtils';
 import { encodeForUrl } from '../utils/sharing';
 import type { Recipe, Ingredient, MealPlan } from '../types';
 import { STORAGE_KEYS, API_CONFIG } from '../constants';
+import { translations } from '../constants/translations';
 import { handlers } from './mocks/handlers';
 
 const API_URL = `${API_CONFIG.BASE_URL}/${API_CONFIG.MODEL}:generateContent`;
@@ -113,6 +114,8 @@ describe('App URL Parameter Decoding', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockLocation.search = '';
+        // Pin language so assertions can compare against the exact English translation.
+        localStorage.setItem(STORAGE_KEYS.LANGUAGE, 'English');
     });
 
     describe('Recipe URL parameter', () => {
@@ -147,11 +150,8 @@ describe('App URL Parameter Decoding', () => {
 
             renderWithSettings(<App />);
 
-            // Error notification should be shown (it's rendered in SettingsPanel)
             await waitFor(() => {
-                const errorText = screen.queryByText(/Invalid shared recipe data/i) ||
-                                screen.queryByText(/The link may be corrupted/i);
-                expect(errorText).toBeInTheDocument();
+                expect(screen.getByText(translations.English.invalidSharedData)).toBeInTheDocument();
             }, { timeout: 3000 });
         });
 
@@ -163,11 +163,8 @@ describe('App URL Parameter Decoding', () => {
 
             renderWithSettings(<App />);
 
-            // Error notification should be shown (it's rendered in SettingsPanel)
             await waitFor(() => {
-                const errorText = screen.queryByText(/Invalid shared recipe data/i) ||
-                                screen.queryByText(/The link may be corrupted/i);
-                expect(errorText).toBeInTheDocument();
+                expect(screen.getByText(translations.English.invalidSharedData)).toBeInTheDocument();
             }, { timeout: 3000 });
         });
     });
@@ -197,11 +194,8 @@ describe('App URL Parameter Decoding', () => {
 
             renderWithSettings(<App />);
 
-            // Error notification should be shown (it's rendered in SettingsPanel)
             await waitFor(() => {
-                const errorText = screen.queryByText(/Invalid shared shopping list data/i) ||
-                                screen.queryByText(/The link may be corrupted/i);
-                expect(errorText).toBeInTheDocument();
+                expect(screen.getByText(translations.English.invalidSharedData)).toBeInTheDocument();
             }, { timeout: 3000 });
         });
     });
@@ -353,9 +347,7 @@ describe('App URL Parameter Decoding', () => {
             // Notification is initialized synchronously from t.invalidSharedData
             // via a lazy useState initializer (no setState-in-effect).
             await waitFor(() => {
-                const errorText = screen.queryByText(/Invalid shared recipe data/i) ||
-                                screen.queryByText(/The link may be corrupted/i);
-                expect(errorText).toBeInTheDocument();
+                expect(screen.getByText(translations.English.invalidSharedData)).toBeInTheDocument();
             }, { timeout: 3000 });
         });
     });

--- a/src/__tests__/utils/sharedUrlParams.test.ts
+++ b/src/__tests__/utils/sharedUrlParams.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { parseSharedUrlParams } from '../../utils/sharedUrlParams';
+import { encodeForUrl } from '../../utils/sharing';
+import type { Recipe, Ingredient } from '../../types';
+
+const mockLocation = new URL('http://localhost:3000');
+Object.defineProperty(window, 'location', {
+    value: mockLocation,
+    writable: true,
+    configurable: true,
+});
+
+const validRecipe: Recipe = {
+    id: 'r1',
+    title: 'Tomato Soup',
+    time: '20 min',
+    ingredients: [{ item: 'Tomato', amount: '4', unit: 'pcs' }],
+    instructions: ['Simmer'],
+    usedIngredients: [],
+    missingIngredients: [],
+};
+
+const validShoppingList: Ingredient[] = [
+    { item: 'Milk', amount: '1', unit: 'L' },
+    { item: 'Bread', amount: '1', unit: 'loaf' },
+];
+
+describe('parseSharedUrlParams', () => {
+    beforeEach(() => {
+        mockLocation.search = '';
+    });
+
+    it('returns all-null when no URL params are present', () => {
+        const result = parseSharedUrlParams();
+        expect(result).toEqual({
+            recipe: null,
+            shoppingList: null,
+            hasInvalidData: false,
+        });
+    });
+
+    it('decodes a valid ?recipe= param into the recipe field', () => {
+        const encoded = encodeForUrl(validRecipe);
+        mockLocation.search = `?recipe=${encodeURIComponent(encoded)}`;
+
+        const result = parseSharedUrlParams();
+
+        expect(result.recipe).toEqual(validRecipe);
+        expect(result.shoppingList).toBeNull();
+        expect(result.hasInvalidData).toBe(false);
+    });
+
+    it('flags hasInvalidData when ?recipe= contains invalid base64', () => {
+        mockLocation.search = '?recipe=invalid-base64-data';
+
+        const result = parseSharedUrlParams();
+
+        expect(result.recipe).toBeNull();
+        expect(result.shoppingList).toBeNull();
+        expect(result.hasInvalidData).toBe(true);
+    });
+
+    it('flags hasInvalidData when ?recipe= decodes to an object that fails schema validation', () => {
+        const encoded = encodeForUrl({ not: 'a recipe' });
+        mockLocation.search = `?recipe=${encodeURIComponent(encoded)}`;
+
+        const result = parseSharedUrlParams();
+
+        expect(result.recipe).toBeNull();
+        expect(result.hasInvalidData).toBe(true);
+    });
+
+    it('decodes a valid ?shoppingList= param into the shoppingList field', () => {
+        const encoded = encodeForUrl(validShoppingList);
+        mockLocation.search = `?shoppingList=${encodeURIComponent(encoded)}`;
+
+        const result = parseSharedUrlParams();
+
+        expect(result.recipe).toBeNull();
+        expect(result.shoppingList).toEqual(validShoppingList);
+        expect(result.hasInvalidData).toBe(false);
+    });
+
+    it('flags hasInvalidData when ?shoppingList= contains invalid base64', () => {
+        mockLocation.search = '?shoppingList=invalid-base64-data';
+
+        const result = parseSharedUrlParams();
+
+        expect(result.recipe).toBeNull();
+        expect(result.shoppingList).toBeNull();
+        expect(result.hasInvalidData).toBe(true);
+    });
+
+    it('flags hasInvalidData when ?shoppingList= decodes to data that fails schema validation', () => {
+        const encoded = encodeForUrl({ not: 'an array' });
+        mockLocation.search = `?shoppingList=${encodeURIComponent(encoded)}`;
+
+        const result = parseSharedUrlParams();
+
+        expect(result.shoppingList).toBeNull();
+        expect(result.hasInvalidData).toBe(true);
+    });
+
+    it('prefers ?recipe= over ?shoppingList= when both are present (recipe branch wins)', () => {
+        const encodedRecipe = encodeForUrl(validRecipe);
+        const encodedList = encodeForUrl(validShoppingList);
+        mockLocation.search =
+            `?recipe=${encodeURIComponent(encodedRecipe)}` +
+            `&shoppingList=${encodeURIComponent(encodedList)}`;
+
+        const result = parseSharedUrlParams();
+
+        expect(result.recipe).toEqual(validRecipe);
+        expect(result.shoppingList).toBeNull();
+        expect(result.hasInvalidData).toBe(false);
+    });
+
+    it('returns hasInvalidData when ?recipe= is invalid even if ?shoppingList= would be valid', () => {
+        const encodedList = encodeForUrl(validShoppingList);
+        mockLocation.search =
+            '?recipe=invalid-base64-data' +
+            `&shoppingList=${encodeURIComponent(encodedList)}`;
+
+        const result = parseSharedUrlParams();
+
+        expect(result.recipe).toBeNull();
+        expect(result.shoppingList).toBeNull();
+        expect(result.hasInvalidData).toBe(true);
+    });
+});

--- a/src/utils/sharedUrlParams.ts
+++ b/src/utils/sharedUrlParams.ts
@@ -4,7 +4,7 @@ import { RecipeSchema, IngredientSchema } from '../services/llm';
 import { URL_PARAMS } from '../constants';
 import type { Recipe, Ingredient } from '../types';
 
-export interface SharedUrlData {
+interface SharedUrlData {
     recipe: Recipe | null;
     shoppingList: Ingredient[] | null;
     hasInvalidData: boolean;

--- a/src/utils/sharedUrlParams.ts
+++ b/src/utils/sharedUrlParams.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { decodeFromUrl } from './sharing';
+import { RecipeSchema, IngredientSchema } from '../services/llm';
+import { URL_PARAMS } from '../constants';
+import type { Recipe, Ingredient } from '../types';
+
+export interface SharedUrlData {
+    recipe: Recipe | null;
+    shoppingList: Ingredient[] | null;
+    hasInvalidData: boolean;
+}
+
+// Parse shared-link URL params once. Pure (no React deps) so it can feed
+// lazy useState initializers, avoiding a setState-in-effect on mount.
+// `recipe` takes precedence when both params are present.
+export function parseSharedUrlParams(): SharedUrlData {
+    const searchParams = new URLSearchParams(window.location.search);
+    const recipeParam = searchParams.get(URL_PARAMS.RECIPE);
+    const shoppingListParam = searchParams.get(URL_PARAMS.SHOPPING_LIST);
+
+    if (recipeParam) {
+        const decoded = decodeFromUrl<Recipe>(decodeURIComponent(recipeParam), RecipeSchema);
+        return { recipe: decoded, shoppingList: null, hasInvalidData: !decoded };
+    }
+    if (shoppingListParam) {
+        const decoded = decodeFromUrl<Ingredient[]>(decodeURIComponent(shoppingListParam), z.array(IngredientSchema));
+        return { recipe: null, shoppingList: decoded, hasInvalidData: !decoded };
+    }
+    return { recipe: null, shoppingList: null, hasInvalidData: false };
+}


### PR DESCRIPTION
## Summary

Resolves the unaddressed review comments from #205 post-merge.

- **Extracts `parseSharedUrlParams`** from `App.tsx` into `src/utils/sharedUrlParams.ts`. Splitting it out makes it directly unit-testable and keeps `App.tsx` clean of the `react-refresh/only-export-components` exception that an inline export would otherwise require.
- **Adds `src/__tests__/utils/sharedUrlParams.test.ts`** with 9 cases covering all five branches of the function plus mutual exclusivity:
  - no params, valid `?recipe=`, invalid `?recipe=` (bad base64 + schema-fail), valid `?shoppingList=`, invalid `?shoppingList=` (bad base64 + schema-fail), and both params present (recipe wins).
  - This closes the 75% patch-coverage gap codecov flagged on #205.
- **Tightens three assertions in `App.test.tsx`** that were non-falsifiable. The previous regex `/The link may be corrupted/i` matched both the deleted hardcoded fallback string *and* the current translation, so the test could not distinguish the new lazy-init code path from the old code. Each assertion now compares against `translations.English.invalidSharedData` directly, with the language pinned via `localStorage` in `beforeEach`.

## Why these were follow-ups, not blockers

#205 had its `react-hooks/set-state-in-effect` fix verified by behavioural tests, so the merge was safe. The two outstanding comments (direct unit tests + falsifiable assertions) and the codecov delta were quality issues worth fixing but did not warrant blocking. Bundling them here keeps the change scoped.

The fourth review comment (gemini-code-assist's fallback-string suggestion) was already applied during #205 — `App.tsx:74` reads `t.invalidSharedData || "Invalid shared data. The link may be corrupted."`.

## Verification

- `npm run lint` clean.
- `npm run build` clean (TypeScript + Vite).
- `npm test -- --run`: 399 passed, 3 skipped (was 390 before; +9 from the new file).

## Test plan

- [ ] CI lint + build + test pass.
- [ ] Codecov patch coverage for the new file is 100%.

https://claude.ai/code/session_01XoPnSEpfWbMQdoTVBVsGNE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoPnSEpfWbMQdoTVBVsGNE)_