### PR TITLE
fix: refresh React state when Gist sync overwrites localStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
 *.local
 
 # Editor directories and files

--- a/src/__tests__/hooks/useGistSync.test.ts
+++ b/src/__tests__/hooks/useGistSync.test.ts
@@ -276,6 +276,40 @@ describe('useGistSync', () => {
     expect(syncResult.current.status).toBe('synced');
   });
 
+  it('does not push when an external write happens after the initial pull completes', async () => {
+    // Locks in the `source !== 'internal'` defensive filter in the change-bus
+    // listener: even if some non-sync code path performs an external write
+    // (e.g. a future "pull now" button) after the initial pull is done, it
+    // must not be misread as a user edit and pushed back to the gist.
+    configureSync();
+    const remote = makeRemotePayload({ data: {} });
+    const patchSpy = vi.fn();
+
+    server.use(
+      http.get(GIST_URL, () => HttpResponse.json(gistWithPayload(remote))),
+      http.patch(GIST_URL, () => {
+        patchSpy();
+        return HttpResponse.json({ id: GIST_ID, files: {} });
+      }),
+    );
+
+    const { result } = renderHook(() => useGistSync());
+    await waitFor(() => expect(result.current.status).toBe('synced'));
+
+    // Now fire an external write directly (after pullCompleteRef is true) so
+    // the listener's earlier `pullCompleteRef` guard cannot mask the bug.
+    const { writeLocalStorageExternal } = await import('@/hooks/useLocalStorage');
+    act(() => {
+      writeLocalStorageExternal(STORAGE_KEYS.PANTRY_ITEMS, [
+        { id: 'x', name: 'X', amount: '1' },
+      ]);
+    });
+
+    await new Promise((r) => setTimeout(r, GIST_API.PUSH_DEBOUNCE_MS + 500));
+    expect(patchSpy).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('synced');
+  });
+
   it('clears mounted state when a synced key is absent from the remote payload', async () => {
     // Mirrors the user scenario: a recipe is deleted on another device, then
     // the local page pulls — the local UI must drop the now-removed entry.

--- a/src/__tests__/hooks/useGistSync.test.ts
+++ b/src/__tests__/hooks/useGistSync.test.ts
@@ -228,6 +228,81 @@ describe('useGistSync', () => {
     expect(patchSpy).not.toHaveBeenCalled();
   });
 
+  it('updates a mounted useLocalStorage hook with the pulled value (no reload required)', async () => {
+    // Regression test for the bug where applySyncPayload wrote directly to
+    // localStorage but mounted useLocalStorage hooks kept showing stale state
+    // (e.g. deleted recipes/ingredients still visible until manual reload).
+    configureSync();
+    const remote = makeRemotePayload();
+    const patchSpy = vi.fn();
+    server.use(
+      http.get(GIST_URL, () => HttpResponse.json(gistWithPayload(remote))),
+      http.patch(GIST_URL, () => {
+        patchSpy();
+        return HttpResponse.json({ id: GIST_ID, files: {} });
+      }),
+    );
+
+    // Pre-populate local state so the hook starts with something different
+    // from the incoming remote payload.
+    localStorage.setItem(
+      STORAGE_KEYS.PANTRY_ITEMS,
+      JSON.stringify([{ id: 'local', name: 'LocalItem', amount: '9' }]),
+    );
+
+    const { useLocalStorage } = await import('@/hooks/useLocalStorage');
+    const { result: pantryResult } = renderHook(() =>
+      useLocalStorage<{ id: string; name: string; amount: string }[]>(
+        STORAGE_KEYS.PANTRY_ITEMS,
+        [],
+      ),
+    );
+    // Sanity check: hook starts on the local value.
+    expect(pantryResult.current[0]).toEqual([{ id: 'local', name: 'LocalItem', amount: '9' }]);
+
+    const { result: syncResult } = renderHook(() => useGistSync());
+    await waitFor(() => expect(syncResult.current.status).toBe('synced'));
+
+    // After the pull, the hook must reflect the remote value WITHOUT a remount.
+    await waitFor(() =>
+      expect(pantryResult.current[0]).toEqual([{ id: 'r1', name: 'RemoteItem', amount: '1' }]),
+    );
+
+    // And we must NOT echo the just-pulled values back as a push: that would
+    // burn a network round-trip on every page load and could clobber a
+    // newer remote update racing with us.
+    await new Promise((r) => setTimeout(r, GIST_API.PUSH_DEBOUNCE_MS + 500));
+    expect(patchSpy).not.toHaveBeenCalled();
+    expect(syncResult.current.status).toBe('synced');
+  });
+
+  it('clears mounted state when a synced key is absent from the remote payload', async () => {
+    // Mirrors the user scenario: a recipe is deleted on another device, then
+    // the local page pulls — the local UI must drop the now-removed entry.
+    configureSync();
+    // Remote payload omits MEAL_PLAN to simulate "deleted on another device".
+    const remote = makeRemotePayload({ data: {} });
+    server.use(http.get(GIST_URL, () => HttpResponse.json(gistWithPayload(remote))));
+
+    localStorage.setItem(
+      STORAGE_KEYS.MEAL_PLAN,
+      JSON.stringify({ recipes: [{ id: 'r', title: 'Stale', time: '10', ingredients: [], instructions: [], usedIngredients: [] }], shoppingList: [] }),
+    );
+
+    const { useLocalStorage } = await import('@/hooks/useLocalStorage');
+    const { result: mealPlanResult } = renderHook(() =>
+      useLocalStorage<unknown | null>(STORAGE_KEYS.MEAL_PLAN, null),
+    );
+    expect(mealPlanResult.current[0]).not.toBeNull();
+
+    const { result: syncResult } = renderHook(() => useGistSync());
+    await waitFor(() => expect(syncResult.current.status).toBe('synced'));
+
+    // Hook must reset to its initial value when the key is removed externally.
+    await waitFor(() => expect(mealPlanResult.current[0]).toBeNull());
+    expect(localStorage.getItem(STORAGE_KEYS.MEAL_PLAN)).toBeNull();
+  });
+
   it('acknowledgePull clears the justPulledFromRemote flag', async () => {
     configureSync();
     const remote = makeRemotePayload();

--- a/src/__tests__/hooks/useLocalStorage.test.ts
+++ b/src/__tests__/hooks/useLocalStorage.test.ts
@@ -84,7 +84,11 @@ describe('useLocalStorage', () => {
     expect(result2.current[0]).toEqual(newArray);
   });
 
-  it('removes item from localStorage when set to null', () => {
+  it('persists null as the JSON literal "null" (only undefined removes the key)', () => {
+    // Explicit null is JSON-encoded so that an external `null` write
+    // (e.g. from Gist sync) is preserved instead of being silently deleted
+    // and echoed back to the remote as a removal. See the external-write
+    // round-trip test below.
     const { result } = renderHook(() => useLocalStorage<string | null>('test-null', 'initial'));
 
     act(() => {
@@ -95,7 +99,11 @@ describe('useLocalStorage', () => {
     act(() => {
       result.current[1](null);
     });
-    expect(localStorage.getItem('test-null')).toBeNull();
+    expect(localStorage.getItem('test-null')).toBe('null');
+
+    // And the persisted "null" parses back to null on remount.
+    const { result: result2 } = renderHook(() => useLocalStorage<string | null>('test-null', 'initial'));
+    expect(result2.current[0]).toBeNull();
   });
 
   it('removes item from localStorage when set to undefined', () => {
@@ -452,6 +460,59 @@ describe('useLocalStorage', () => {
 
       expect(a.current[0]).toBe('from-external');
       expect(b.current[0]).toBe('from-external');
+    });
+
+    it('round-trips an explicit null value from an external write without re-emitting', () => {
+      // Regression for the gemini-code-assist review on PR #207: if Gist sync
+      // pushes `null` for a key, the hook must (a) reflect null in state,
+      // (b) keep the persisted "null" intact, and (c) NOT emit an `internal`
+      // change event — otherwise useGistSync would schedule an echo push that
+      // strips the field from the remote.
+      const internalEvents: Array<{ key: string; value: unknown }> = [];
+      const unsubscribe = subscribeToLocalStorageChanges((event) => {
+        if (event.source === 'internal' && event.key === 'ext-null-roundtrip') {
+          internalEvents.push({ key: event.key, value: event.value });
+        }
+      });
+
+      const { result } = renderHook(() =>
+        useLocalStorage<{ x: number } | null>('ext-null-roundtrip', { x: 0 }),
+      );
+      // Drain the mount-time internal write that persists the initial value.
+      internalEvents.length = 0;
+
+      act(() => {
+        writeLocalStorageExternal('ext-null-roundtrip', null);
+      });
+
+      expect(result.current[0]).toBeNull();
+      expect(localStorage.getItem('ext-null-roundtrip')).toBe('null');
+      expect(internalEvents).toEqual([]);
+
+      unsubscribe();
+    });
+
+    it('uses the latest initialValue when the key is removed externally after a re-render', () => {
+      // The subscription effect captures initialValue via a ref so that a
+      // parent re-render with a new default does not leave us with a stale
+      // value when an external removal asks us to reset.
+      let currentDefault = 'first-default';
+      const { result, rerender } = renderHook(() =>
+        useLocalStorage<string>('ext-stale-default', currentDefault),
+      );
+
+      act(() => {
+        result.current[1]('user-set');
+      });
+
+      currentDefault = 'second-default';
+      rerender();
+
+      act(() => {
+        writeLocalStorageExternal('ext-stale-default', undefined);
+      });
+
+      expect(result.current[0]).toBe('second-default');
     });
 
     it('unsubscribes on unmount so external writes do not leak into stale state', () => {

--- a/src/__tests__/hooks/useLocalStorage.test.ts
+++ b/src/__tests__/hooks/useLocalStorage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useLocalStorage, subscribeToLocalStorageChanges } from '@/hooks/useLocalStorage';
+import { useLocalStorage, subscribeToLocalStorageChanges, writeLocalStorageExternal } from '@/hooks/useLocalStorage';
 
 describe('useLocalStorage', () => {
   beforeEach(() => {
@@ -239,7 +239,7 @@ describe('useLocalStorage', () => {
         result.current[1]('new-value');
       });
 
-      expect(listener).toHaveBeenCalledWith({ key: 'test-emit', value: 'new-value' });
+      expect(listener).toHaveBeenCalledWith({ key: 'test-emit', value: 'new-value', source: 'internal' });
       unsubscribe();
     });
 
@@ -249,7 +249,7 @@ describe('useLocalStorage', () => {
 
       renderHook(() => useLocalStorage<number>('test-emit-mount', 42));
 
-      expect(listener).toHaveBeenCalledWith({ key: 'test-emit-mount', value: 42 });
+      expect(listener).toHaveBeenCalledWith({ key: 'test-emit-mount', value: 42, source: 'internal' });
       unsubscribe();
     });
 
@@ -310,11 +310,161 @@ describe('useLocalStorage', () => {
       });
 
       expect(broken).toHaveBeenCalled();
-      expect(good).toHaveBeenCalledWith({ key: 'test-isolation', value: 'v' });
+      expect(good).toHaveBeenCalledWith({ key: 'test-isolation', value: 'v', source: 'internal' });
 
       unsubscribeA();
       unsubscribeB();
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('writeLocalStorageExternal', () => {
+    it('writes the value to localStorage as JSON', () => {
+      writeLocalStorageExternal('ext-key', { a: 1 });
+      expect(localStorage.getItem('ext-key')).toBe(JSON.stringify({ a: 1 }));
+    });
+
+    it('removes the key when value is undefined (the "absent from payload" sentinel)', () => {
+      localStorage.setItem('ext-rm-u', JSON.stringify('present'));
+      writeLocalStorageExternal('ext-rm-u', undefined);
+      expect(localStorage.getItem('ext-rm-u')).toBeNull();
+    });
+
+    it('writes literal null rather than removing the key', () => {
+      // Preserves the original applySyncPayload semantics: only key absence
+      // removes; an explicit null in the payload is persisted as JSON `null`.
+      writeLocalStorageExternal('ext-null', null);
+      expect(localStorage.getItem('ext-null')).toBe('null');
+    });
+
+    it('emits an "external" change event', () => {
+      const listener = vi.fn();
+      const unsubscribe = subscribeToLocalStorageChanges(listener);
+
+      writeLocalStorageExternal('ext-emit', [1, 2, 3]);
+
+      expect(listener).toHaveBeenCalledWith({
+        key: 'ext-emit',
+        value: [1, 2, 3],
+        source: 'external',
+      });
+      unsubscribe();
+    });
+
+    it('emits with value undefined when the key is removed', () => {
+      const listener = vi.fn();
+      const unsubscribe = subscribeToLocalStorageChanges(listener);
+
+      writeLocalStorageExternal('ext-emit-rm', undefined);
+
+      expect(listener).toHaveBeenCalledWith({
+        key: 'ext-emit-rm',
+        value: undefined,
+        source: 'external',
+      });
+      unsubscribe();
+    });
+  });
+
+  describe('useLocalStorage external-write reactivity (Gist sync bug fix)', () => {
+    it('updates state when writeLocalStorageExternal overwrites the same key', () => {
+      const { result } = renderHook(() => useLocalStorage<string[]>('ext-react', ['a']));
+      expect(result.current[0]).toEqual(['a']);
+
+      act(() => {
+        writeLocalStorageExternal('ext-react', ['b', 'c']);
+      });
+
+      // Without the fix this would still be ['a'] because useState only reads
+      // localStorage on the first render. This is the regression the bug
+      // report describes: deleted/changed items still visible until reload.
+      expect(result.current[0]).toEqual(['b', 'c']);
+      expect(localStorage.getItem('ext-react')).toBe(JSON.stringify(['b', 'c']));
+    });
+
+    it('falls back to the initial value when an external write removes the key', () => {
+      const { result } = renderHook(() => useLocalStorage<string>('ext-removed', 'default'));
+
+      act(() => {
+        result.current[1]('user-set');
+      });
+      expect(result.current[0]).toBe('user-set');
+
+      act(() => {
+        writeLocalStorageExternal('ext-removed', undefined);
+      });
+
+      // Hook resets to initialValue; its persistence effect then writes that
+      // initial back to localStorage so the hook's own invariant (state ⇔
+      // localStorage) holds. This matches what would happen after a reload.
+      expect(result.current[0]).toBe('default');
+      expect(localStorage.getItem('ext-removed')).toBe(JSON.stringify('default'));
+    });
+
+    it('keeps localStorage cleared when initialValue is null and key is removed externally', () => {
+      // Mirrors the MEAL_PLAN sync case: omitted from remote payload → local
+      // null → effect sees next=null, current=null → no rewrite, no echo.
+      const { result } = renderHook(() => useLocalStorage<{ x: number } | null>('ext-null-init', null));
+
+      act(() => {
+        result.current[1]({ x: 1 });
+      });
+      expect(localStorage.getItem('ext-null-init')).toBe(JSON.stringify({ x: 1 }));
+
+      act(() => {
+        writeLocalStorageExternal('ext-null-init', undefined);
+      });
+
+      expect(result.current[0]).toBeNull();
+      expect(localStorage.getItem('ext-null-init')).toBeNull();
+    });
+
+    it('ignores external writes targeting a different key', () => {
+      const { result } = renderHook(() => useLocalStorage<number>('ext-mine', 1));
+
+      act(() => {
+        writeLocalStorageExternal('ext-other', 999);
+      });
+
+      expect(result.current[0]).toBe(1);
+    });
+
+    it('does NOT react to internal writes from other useLocalStorage instances on the same key', () => {
+      // Two hooks for the same key are an unusual pattern but we want to prove
+      // that external-only filtering keeps internal write semantics intact:
+      // each instance owns its own state and does not get re-broadcast to itself.
+      const { result: a } = renderHook(() => useLocalStorage<string>('ext-shared', 'init'));
+      const { result: b } = renderHook(() => useLocalStorage<string>('ext-shared', 'init'));
+
+      act(() => {
+        a.current[1]('from-a');
+      });
+
+      // Only `a` receives the new value through its own setState; `b` stays
+      // on its own state until something explicitly external happens.
+      expect(a.current[0]).toBe('from-a');
+      expect(b.current[0]).toBe('init');
+
+      // An external write reaches both instances.
+      act(() => {
+        writeLocalStorageExternal('ext-shared', 'from-external');
+      });
+
+      expect(a.current[0]).toBe('from-external');
+      expect(b.current[0]).toBe('from-external');
+    });
+
+    it('unsubscribes on unmount so external writes do not leak into stale state', () => {
+      const { result, unmount } = renderHook(() =>
+        useLocalStorage<string>('ext-unmount', 'initial'),
+      );
+
+      unmount();
+
+      // Should not throw and should not be observable from the (unmounted) hook.
+      expect(() => writeLocalStorageExternal('ext-unmount', 'after-unmount')).not.toThrow();
+      // Last rendered value remains, since the hook is gone.
+      expect(result.current[0]).toBe('initial');
     });
   });
 });

--- a/src/hooks/useGistSync.ts
+++ b/src/hooks/useGistSync.ts
@@ -166,8 +166,11 @@ export const useGistSync = (): UseGistSyncResult => {
             }
         };
 
-        const unsubscribe = subscribeToLocalStorageChanges(({ key }) => {
+        const unsubscribe = subscribeToLocalStorageChanges(({ key, source }) => {
             if (!pullCompleteRef.current) return;
+            // External writes (e.g. our own applySyncPayload) must not trigger
+            // a push — that would echo the value we just pulled back to the gist.
+            if (source !== 'internal') return;
             if (!SYNCED_STORAGE_KEYS.includes(key)) return;
 
             setStatus('pending');

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -5,10 +5,22 @@ import { useState, useEffect } from 'react';
  * published here so that cross-cutting consumers (e.g. Gist sync) can react
  * to changes without each call-site being refactored.
  *
+ * Events carry a `source` so consumers can distinguish writes that originated
+ * from a useLocalStorage setter (`'internal'`) from writes performed directly
+ * against localStorage by other code paths such as the Gist-sync apply
+ * (`'external'`). Internal writes drive sync push; external writes drive the
+ * hook-side state refresh that lets the UI re-render after sync overwrites
+ * localStorage.
+ *
  * The browser's own `storage` event only fires in OTHER tabs, so it cannot
  * be used for same-tab change detection.
  */
-export type LocalStorageChangeListener = (event: { key: string; value: unknown }) => void;
+export type LocalStorageChangeSource = 'internal' | 'external';
+export type LocalStorageChangeListener = (event: {
+    key: string;
+    value: unknown;
+    source: LocalStorageChangeSource;
+}) => void;
 
 const listeners = new Set<LocalStorageChangeListener>();
 
@@ -19,14 +31,36 @@ export const subscribeToLocalStorageChanges = (listener: LocalStorageChangeListe
     };
 };
 
-const emitLocalStorageChange = (key: string, value: unknown): void => {
+const emitLocalStorageChange = (
+    key: string,
+    value: unknown,
+    source: LocalStorageChangeSource,
+): void => {
     for (const listener of listeners) {
         try {
-            listener({ key, value });
+            listener({ key, value, source });
         } catch (error) {
             console.error('localStorage change listener threw:', error);
         }
     }
+};
+
+/**
+ * Performs a localStorage write that originates outside any useLocalStorage
+ * hook (e.g. when Gist sync overwrites local state with the remote payload).
+ * Mounted useLocalStorage hooks for the same key will pick up the new value
+ * via the change-event subscription, so the UI re-renders without a reload.
+ *
+ * Pass `undefined` to remove the key entirely; mounted hooks will reset to
+ * their `initialValue`. Use `null` to explicitly write a JSON `null`.
+ */
+export const writeLocalStorageExternal = (key: string, value: unknown): void => {
+    if (value === undefined) {
+        localStorage.removeItem(key);
+    } else {
+        localStorage.setItem(key, JSON.stringify(value));
+    }
+    emitLocalStorageChange(key, value, 'external');
 };
 
 export function useLocalStorage<T>(key: string, initialValue: T) {
@@ -45,19 +79,44 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
     // that external write succeeded, so the lint suppression is intentional.
     useEffect(() => {
         try {
-            if (state === null || state === undefined) {
+            const next = (state === null || state === undefined) ? null : JSON.stringify(state);
+            const current = localStorage.getItem(key);
+            // Idempotent guard: if localStorage already holds this exact value
+            // (e.g. we just absorbed an external write from Gist sync), skip
+            // the write AND the emit so we don't echo it back as an `internal`
+            // event that would trigger a redundant sync push.
+            if (current === next) {
+                // eslint-disable-next-line react-hooks/set-state-in-effect
+                setPersistError(false);
+                return;
+            }
+            if (next === null) {
                 localStorage.removeItem(key);
             } else {
-                localStorage.setItem(key, JSON.stringify(state));
+                localStorage.setItem(key, next);
             }
-            emitLocalStorageChange(key, state);
-            // eslint-disable-next-line react-hooks/set-state-in-effect
+            emitLocalStorageChange(key, state, 'internal');
             setPersistError(false);
         } catch (error) {
             setPersistError(true);
             console.error(`Error saving localStorage key "${key}":`, error);
         }
     }, [key, state]);
+
+    // Pick up writes that bypass this hook (sync apply, future imports, etc.)
+    // so the component re-renders without requiring a page reload. `undefined`
+    // signals "key removed" → reset to initialValue.
+    useEffect(() => {
+        return subscribeToLocalStorageChanges((event) => {
+            if (event.source !== 'external') return;
+            if (event.key !== key) return;
+            setState((event.value === undefined ? initialValue : event.value) as T);
+        });
+        // initialValue intentionally excluded: it is only consulted when an
+        // external write removes the key, and re-subscribing on every render
+        // would defeat the purpose. Treat it as a stable mount-time default.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [key]);
 
     return [state, setState, persistError] as const;
 }

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 /**
  * Module-local event bus: every successful write from useLocalStorage is
@@ -75,17 +75,31 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
     });
     const [persistError, setPersistError] = useState(false);
 
+    // Track initialValue in a ref so the external-write subscription effect
+    // can read the latest default without re-subscribing on every render.
+    const initialValueRef = useRef(initialValue);
+    useEffect(() => {
+        initialValueRef.current = initialValue;
+    }, [initialValue]);
+
     // Effect syncs state to localStorage; setPersistError reflects whether
     // that external write succeeded, so the lint suppression is intentional.
     useEffect(() => {
         try {
-            const next = (state === null || state === undefined) ? null : JSON.stringify(state);
+            // Only `undefined` removes the key; `null` is JSON-encoded as
+            // `"null"` so an external `null` write (e.g. from Gist sync)
+            // round-trips through the idempotency guard below instead of
+            // being silently deleted and then echoed back to the remote.
+            const next = state === undefined ? null : JSON.stringify(state);
             const current = localStorage.getItem(key);
-            // Idempotent guard: if localStorage already holds this exact value
-            // (e.g. we just absorbed an external write from Gist sync), skip
-            // the write AND the emit so we don't echo it back as an `internal`
-            // event that would trigger a redundant sync push.
-            if (current === next) {
+            // Idempotent guard: skip when storage already matches what we'd
+            // write (e.g. we just absorbed an external write from Gist sync).
+            // Also treat absence (`current === null`) and the literal `"null"`
+            // (`next === 'null'`) as equivalent so that resetting to a null
+            // initialValue after an external removal does not silently
+            // re-persist `"null"` and echo it back to the remote on the next
+            // sync push.
+            if (current === next || (next === 'null' && current === null)) {
                 // eslint-disable-next-line react-hooks/set-state-in-effect
                 setPersistError(false);
                 return;
@@ -105,17 +119,14 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
 
     // Pick up writes that bypass this hook (sync apply, future imports, etc.)
     // so the component re-renders without requiring a page reload. `undefined`
-    // signals "key removed" → reset to initialValue.
+    // signals "key removed" → reset to initialValue (read from the ref to
+    // avoid capturing a stale default if the parent re-renders).
     useEffect(() => {
         return subscribeToLocalStorageChanges((event) => {
             if (event.source !== 'external') return;
             if (event.key !== key) return;
-            setState((event.value === undefined ? initialValue : event.value) as T);
+            setState((event.value === undefined ? initialValueRef.current : event.value) as T);
         });
-        // initialValue intentionally excluded: it is only consulted when an
-        // external write removes the key, and re-subscribing on every render
-        // would defeat the purpose. Treat it as a stable mount-time default.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [key]);
 
     return [state, setState, persistError] as const;

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -99,6 +99,14 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
             // initialValue after an external removal does not silently
             // re-persist `"null"` and echo it back to the remote on the next
             // sync push.
+            //
+            // The guard is intentionally NOT generalised to all defaults: a
+            // generalised guard would also skip the mount-time eager persist
+            // for fresh hooks, which the App's storage-error-notification flow
+            // relies on for early QuotaExceededError detection. The only
+            // remaining echo is one debounced sync push when a non-null
+            // default is reset by an external removal — network noise, not a
+            // correctness issue.
             if (current === next || (next === 'null' && current === null)) {
                 // eslint-disable-next-line react-hooks/set-state-in-effect
                 setPersistError(false);

--- a/src/services/gistSync.ts
+++ b/src/services/gistSync.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { GIST_API, SYNCED_STORAGE_KEYS } from '../constants';
+import { writeLocalStorageExternal } from '../hooks/useLocalStorage';
 
 /**
  * Shape of the payload stored in the sync Gist.
@@ -77,15 +78,17 @@ export const buildSyncPayload = (): SyncPayload => {
 /**
  * Applies a sync payload to localStorage, overwriting any synced keys.
  * Keys absent from the payload are removed locally (matches import semantics).
+ *
+ * Writes go through `writeLocalStorageExternal` so that mounted
+ * `useLocalStorage` hooks re-read the new values and React re-renders the UI.
+ * Without this, the page would still show the pre-sync state until reload.
  */
 export const applySyncPayload = (payload: SyncPayload): void => {
     for (const key of SYNCED_STORAGE_KEYS) {
-        const value = payload.data[key];
-        if (value === undefined) {
-            localStorage.removeItem(key);
-            continue;
-        }
-        localStorage.setItem(key, JSON.stringify(value));
+        // `undefined` (key absent from payload) removes the local key, which
+        // tells subscribed useLocalStorage hooks to reset to their initial
+        // value. Any present value (including `null`) is written verbatim.
+        writeLocalStorageExternal(key, payload.data[key]);
     }
 };
 


### PR DESCRIPTION
## Summary

Fixes the bug where, after the on-mount Gist pull, the toast appeared but the UI kept showing pre-sync state (deleted recipes/ingredients still visible) until a manual page reload.

**Root cause:** `applySyncPayload()` writes directly to `localStorage`, but `useLocalStorage` only reads `localStorage` once in its `useState` initializer (mount only). Synced writes never reached React state, so components rendered stale data until reload reseeded the initializer.

**Fix:** extend the existing in-process change bus (`subscribeToLocalStorageChanges`) with a `source` field (`'internal' | 'external'`) and add a `writeLocalStorageExternal` helper.

- `applySyncPayload` now routes through `writeLocalStorageExternal`, which emits an `'external'` event.
- `useLocalStorage` subscribes to `'external'` events for its own key and calls `setState`, so the UI re-renders immediately.
- The persistence effect short-circuits when `localStorage` already holds the same serialized value, so absorbing an external write does not echo back as an `'internal'` event.
- `useGistSync` ignores non-`'internal'` events as a second-line guard against push echoes.

`applySyncPayload`'s original semantics are preserved: a key absent from the payload (`undefined`) removes it locally; an explicit `null` is written as JSON `null`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — passes
- [x] `npm test` — 412 passed, 3 skipped (integration only)
- [x] New regression test: pulled values reach mounted `useLocalStorage` hooks without a remount.
- [x] New regression test: pulled values that omit a key reset hooks to their initial value (mirrors the user-reported "deleted recipes still showing" scenario).
- [x] New regression test: applying a pull does not trigger an echo push (`PATCH` count stays 0).
- [x] New tests for `writeLocalStorageExternal` (write, remove via `undefined`, literal `null`, `'external'` emit).
- [x] Existing event-bus tests updated to assert the new `source` field.

https://claude.ai/code/session_01MPzbTWVZqjFNU61dgPMbnk

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPzbTWVZqjFNU61dgPMbnk)_