### PR TITLE
feat: add on-demand AI storage tips for pantry items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.2.0
+**Current version**: 1.2.1
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
-import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, Info } from 'lucide-react';
+import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, Info, Trash2 } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
+import { useStorageTips } from '../hooks/useStorageTips';
 import { API_CONFIG, STORAGE_KEYS } from '../constants';
 import { ApiKeySecurityDialog } from './ApiKeySecurityDialog';
 import { ClearApiKeyDialog } from './ClearApiKeyDialog';
@@ -28,6 +29,7 @@ export const Header: React.FC<HeaderProps> = ({
     syncStatus,
 }) => {
     const { useCopyPaste, setUseCopyPaste, apiKey, setApiKey, language, setLanguage, storageTipsEnabled, setStorageTipsEnabled, t } = useSettings();
+    const { clearAll: clearAllStorageTips, restoreAll: restoreAllStorageTips, hasAnyTips: hasAnyStorageTips } = useStorageTips();
 
     // Check on mount if existing user needs to see the security warning
     const [showSecurityDialog, setShowSecurityDialog] = useState(() => {
@@ -186,6 +188,23 @@ export const Header: React.FC<HeaderProps> = ({
         setPendingModeSwitch(null);
     };
 
+    const handleClearStorageTips = () => {
+        const backup = clearAllStorageTips();
+        onShowNotification({
+            message: t.undo.storageTipsCleared,
+            type: 'undo',
+            action: {
+                label: t.undo.action,
+                ariaLabel: `${t.undo.action} ${t.undo.storageTipsCleared.toLowerCase()}`,
+                onClick: () => {
+                    restoreAllStorageTips(backup);
+                    onClearNotification();
+                }
+            },
+            timeout: 5000
+        });
+    };
+
     return (
         <>
         <header className={`glass-panel !py-2 rounded-none border-x-0 border-t-0 sticky top-0 z-50 mb-4 backdrop-blur-xl transition-all duration-300 ${headerMinimized ? '!py-1' : ''}`}>
@@ -324,6 +343,15 @@ export const Header: React.FC<HeaderProps> = ({
                                                 className={`absolute top-0.5 w-5 h-5 bg-primary rounded-full shadow-md transition-all duration-200 ${storageTipsEnabled ? 'left-6' : 'left-0.5'}`}
                                             />
                                         </button>
+                                        {hasAnyStorageTips && (
+                                            <TooltipButton
+                                                icon={<Trash2 size={14} />}
+                                                tooltip={t.storageTips.clearAll}
+                                                ariaLabel={t.storageTips.clearAll}
+                                                className="!p-1.5 cursor-pointer hover:!text-red-500 hover:!bg-red-500/10"
+                                                onClick={handleClearStorageTips}
+                                            />
+                                        )}
                                     </div>
                                     {storageTipsEnabled && (
                                         <span className="text-xs text-text-muted flex items-center gap-1 pl-6">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2 } from 'lucide-react';
+import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, Info } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { API_CONFIG, STORAGE_KEYS } from '../constants';
 import { ApiKeySecurityDialog } from './ApiKeySecurityDialog';
@@ -27,7 +27,7 @@ export const Header: React.FC<HeaderProps> = ({
     onClearNotification,
     syncStatus,
 }) => {
-    const { useCopyPaste, setUseCopyPaste, apiKey, setApiKey, language, setLanguage, t } = useSettings();
+    const { useCopyPaste, setUseCopyPaste, apiKey, setApiKey, language, setLanguage, storageTipsEnabled, setStorageTipsEnabled, t } = useSettings();
 
     // Check on mount if existing user needs to see the security warning
     const [showSecurityDialog, setShowSecurityDialog] = useState(() => {
@@ -303,6 +303,34 @@ export const Header: React.FC<HeaderProps> = ({
                                     >
                                         <ExternalLink size={14} />
                                     </a>
+                                </div>
+                            )}
+
+                            {!useCopyPaste && (
+                                <div className="flex flex-col gap-1 animate-in fade-in slide-in-from-top-2 duration-300">
+                                    <div className="flex items-center gap-2">
+                                        <Info size={16} className="text-text-muted" aria-hidden="true" />
+                                        <span className={`text-sm transition-colors ${storageTipsEnabled ? 'text-text-main font-medium' : 'text-text-muted'}`}>
+                                            {t.storageTips.label}
+                                        </span>
+                                        <button
+                                            onClick={() => setStorageTipsEnabled(!storageTipsEnabled)}
+                                            className="relative w-12 h-6 bg-white/50 dark:bg-black/30 rounded-full border border-[var(--glass-border)] transition-colors hover:bg-white/70 dark:hover:bg-black/40"
+                                            role="switch"
+                                            aria-checked={storageTipsEnabled}
+                                            aria-label={t.storageTips.label}
+                                        >
+                                            <span
+                                                className={`absolute top-0.5 w-5 h-5 bg-primary rounded-full shadow-md transition-all duration-200 ${storageTipsEnabled ? 'left-6' : 'left-0.5'}`}
+                                            />
+                                        </button>
+                                    </div>
+                                    {storageTipsEnabled && (
+                                        <span className="text-xs text-text-muted flex items-center gap-1 pl-6">
+                                            <Info size={12} aria-hidden="true" />
+                                            {t.storageTips.hint}
+                                        </span>
+                                    )}
                                 </div>
                             )}
 

--- a/src/components/PantryInput.tsx
+++ b/src/components/PantryInput.tsx
@@ -1,8 +1,9 @@
 import React, { useState, forwardRef, useImperativeHandle, useRef, useEffect } from 'react';
-import { Plus, Trash2, Refrigerator } from 'lucide-react';
+import { Plus, Trash2, Refrigerator, Info, Loader2, X } from 'lucide-react';
 import type { PantryItem } from '../types';
 import { generateId } from '../utils/idGenerator';
 import { useSettings } from '../contexts/SettingsContext';
+import { useStorageTips } from '../hooks/useStorageTips';
 import { PanelHeader } from './ui';
 import { VALIDATION } from '../constants';
 
@@ -29,15 +30,49 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
     isMinimized,
     onToggleMinimize
 }, ref) => {
-    const { t } = useSettings();
+    const { t, useCopyPaste, storageTipsEnabled } = useSettings();
+    const tipsActive = storageTipsEnabled && !useCopyPaste;
+    const { getTip, fetchTip, isLoading: isTipLoading, getError: getTipError } = useStorageTips();
     const [name, setName] = useState('');
     const [amount, setAmount] = useState('');
     const [editingItemId, setEditingItemId] = useState<string | null>(null);
     const [editingAmount, setEditingAmount] = useState('');
+    const [openTipForId, setOpenTipForId] = useState<string | null>(null);
     const nameInputRef = useRef<HTMLInputElement>(null);
     const amountInputRef = useRef<HTMLInputElement>(null);
     const editAmountInputRef = useRef<HTMLInputElement>(null);
+    const popoverRef = useRef<HTMLDivElement>(null);
     const isCancellingRef = useRef(false);
+
+    const handleTipClick = (item: PantryItem) => {
+        if (openTipForId === item.id) {
+            setOpenTipForId(null);
+            return;
+        }
+        setOpenTipForId(item.id);
+        if (!getTip(item.name)) {
+            void fetchTip(item.name);
+        }
+    };
+
+    useEffect(() => {
+        if (!openTipForId) return;
+        const handler = (e: MouseEvent) => {
+            const target = e.target as Element | null;
+            if (!target) return;
+            if (popoverRef.current?.contains(target)) return;
+            if (target.closest('[data-storage-tip-trigger="true"]')) return;
+            setOpenTipForId(null);
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [openTipForId]);
+
+    useEffect(() => {
+        if (!tipsActive && openTipForId) {
+            setOpenTipForId(null);
+        }
+    }, [tipsActive, openTipForId]);
 
     // Focus ingredient field on mount
     useEffect(() => {
@@ -119,7 +154,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
     }, [editingItemId]);
 
     return (
-        <div className="glass-panel p-6 flex flex-col gap-6">
+        <div className="glass-panel p-6 flex flex-col gap-6 relative z-20">
             <PanelHeader
                 icon={<Refrigerator className="text-primary" size={24} />}
                 title={t.pantry}
@@ -170,10 +205,66 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                 {t.noVeg}
                             </div>
                         )}
-                        {pantryItems.map((item) => (
+                        {pantryItems.map((item) => {
+                            const cachedTip = tipsActive ? getTip(item.name) : undefined;
+                            const tipLoading = tipsActive && isTipLoading(item.name);
+                            const tipError = tipsActive ? getTipError(item.name) : undefined;
+                            const tipOpen = openTipForId === item.id && tipsActive;
+                            return (
                             <div key={item.id} className="glass-card flex flex-row items-center justify-between p-3 animate-in fade-in slide-in-from-left-2 hover:border-border-hover transition-colors">
                                 <div className="flex flex-row items-center gap-3">
-                                    <div className="w-2 h-2 rounded-full bg-primary shadow-sm shadow-primary/20"></div>
+                                    {tipsActive ? (
+                                        <div className="relative">
+                                            <button
+                                                type="button"
+                                                data-storage-tip-trigger="true"
+                                                onClick={() => handleTipClick(item)}
+                                                className={`w-6 h-6 flex items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10 ${cachedTip ? 'ring-2 ring-primary/40' : ''}`}
+                                                aria-label={`${t.storageTips.iconAriaLabel}: ${item.name}`}
+                                                aria-expanded={tipOpen}
+                                            >
+                                                {tipLoading ? (
+                                                    <Loader2 size={14} className="animate-spin" />
+                                                ) : (
+                                                    <Info size={14} className={cachedTip ? 'fill-primary/15' : ''} />
+                                                )}
+                                            </button>
+                                            {tipOpen && (
+                                                <div
+                                                    ref={popoverRef}
+                                                    role="dialog"
+                                                    aria-label={`${t.storageTips.popoverTitle}: ${item.name}`}
+                                                    className="absolute z-40 top-full left-0 mt-2 w-64 max-w-[80vw] bg-bg-surface border border-border-base rounded-xl p-3 shadow-xl animate-in fade-in slide-in-from-top-1 duration-150"
+                                                >
+                                                    <div className="flex items-center justify-between gap-2 mb-1.5">
+                                                        <span className="text-xs font-semibold text-text-muted uppercase tracking-wide">
+                                                            {t.storageTips.popoverTitle}
+                                                        </span>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => setOpenTipForId(null)}
+                                                            className="text-text-muted hover:text-primary transition-colors p-0.5 rounded-full"
+                                                            aria-label={t.remove}
+                                                        >
+                                                            <X size={14} />
+                                                        </button>
+                                                    </div>
+                                                    {cachedTip ? (
+                                                        <p className="text-sm text-text-main leading-relaxed">{cachedTip}</p>
+                                                    ) : tipLoading ? (
+                                                        <p className="text-sm text-text-muted italic flex items-center gap-2">
+                                                            <Loader2 size={14} className="animate-spin" />
+                                                            {t.storageTips.loading}
+                                                        </p>
+                                                    ) : tipError ? (
+                                                        <p className="text-sm text-red-500">{tipError}</p>
+                                                    ) : null}
+                                                </div>
+                                            )}
+                                        </div>
+                                    ) : (
+                                        <div className="w-2 h-2 rounded-full bg-primary shadow-sm shadow-primary/20"></div>
+                                    )}
                                     <span className="font-semibold text-text-main">{item.name}</span>
                                     {editingItemId === item.id ? (
                                         <input
@@ -207,7 +298,8 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                     <Trash2 size={16} />
                                 </button>
                             </div>
-                        ))}
+                            );
+                        })}
                         {pantryItems.length > 0 && (
                             <div className="flex justify-end mt-2">
                                 <button

--- a/src/components/PantryInput.tsx
+++ b/src/components/PantryInput.tsx
@@ -244,7 +244,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                                             type="button"
                                                             onClick={() => setOpenTipForId(null)}
                                                             className="text-text-muted hover:text-primary transition-colors p-0.5 rounded-full"
-                                                            aria-label={t.close}
+                                                            aria-label={t.storageTips.close}
                                                         >
                                                             <X size={14} />
                                                         </button>

--- a/src/components/PantryInput.tsx
+++ b/src/components/PantryInput.tsx
@@ -244,7 +244,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                                             type="button"
                                                             onClick={() => setOpenTipForId(null)}
                                                             className="text-text-muted hover:text-primary transition-colors p-0.5 rounded-full"
-                                                            aria-label={t.remove}
+                                                            aria-label={t.close}
                                                         >
                                                             <X size={14} />
                                                         </button>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -33,6 +33,8 @@ export const STORAGE_KEYS = {
     GIST_ID: 'gist_sync_id',
     SYNC_UPDATED_AT: 'sync_updated_at',
     GIST_TOKEN_WARNING_SEEN: 'gist_token_warning_seen',
+    STORAGE_TIPS_ENABLED: 'storage_tips_enabled',
+    STORAGE_TIPS_CACHE: 'storage_tips_cache',
 } as const;
 
 /**

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -111,6 +111,8 @@ export const translations = {
             iconAriaLabel: "Storage tip",
             popoverTitle: "Storage tip",
             loading: "Fetching storage tip…",
+            close: "Close",
+            clearAll: "Clear all storage tips",
         },
         copyPaste: {
             title: "Copy & Paste",
@@ -158,6 +160,7 @@ export const translations = {
             pantryEmptied: "Pantry emptied",
             recipeDeleted: "Recipe deleted",
             apiKeyCleared: "API key cleared",
+            storageTipsCleared: "Storage tips cleared",
             action: "Undo"
         },
         apiKeyStoredWarning: "API key stored in local storage",
@@ -329,6 +332,8 @@ export const translations = {
             iconAriaLabel: "Lagerungstipp",
             popoverTitle: "Lagerungstipp",
             loading: "Lade Lagerungstipp…",
+            close: "Schließen",
+            clearAll: "Alle Lagerungstipps löschen",
         },
         copyPaste: {
             title: "Kopieren & Einfügen",
@@ -376,6 +381,7 @@ export const translations = {
             pantryEmptied: "Vorrat geleert",
             recipeDeleted: "Rezept gelöscht",
             apiKeyCleared: "API-Schlüssel gelöscht",
+            storageTipsCleared: "Lagerungstipps gelöscht",
             action: "Rückgängig"
         },
         apiKeyStoredWarning: "API-Schlüssel im lokalen Speicher gespeichert",
@@ -547,6 +553,8 @@ export const translations = {
             iconAriaLabel: "Conseil de conservation",
             popoverTitle: "Conseil de conservation",
             loading: "Chargement du conseil…",
+            close: "Fermer",
+            clearAll: "Effacer tous les conseils de conservation",
         },
         copyPaste: {
             title: "Copier-Coller",
@@ -594,6 +602,7 @@ export const translations = {
             pantryEmptied: "Garde-manger vidé",
             recipeDeleted: "Recette supprimée",
             apiKeyCleared: "Clé API effacée",
+            storageTipsCleared: "Conseils de conservation effacés",
             action: "Annuler"
         },
         apiKeyStoredWarning: "Clé API stockée dans le stockage local",
@@ -765,6 +774,8 @@ export const translations = {
             iconAriaLabel: "Consejo de conservación",
             popoverTitle: "Consejo de conservación",
             loading: "Obteniendo consejo…",
+            close: "Cerrar",
+            clearAll: "Eliminar todos los consejos de conservación",
         },
         copyPaste: {
             title: "Copiar y Pegar",
@@ -812,6 +823,7 @@ export const translations = {
             pantryEmptied: "Despensa vaciada",
             recipeDeleted: "Receta eliminada",
             apiKeyCleared: "Clave API eliminada",
+            storageTipsCleared: "Consejos de conservación eliminados",
             action: "Deshacer"
         },
         apiKeyStoredWarning: "Clave API almacenada en almacenamiento local",

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -105,6 +105,13 @@ export const translations = {
             apiKey: "API Key",
             copyPaste: "Copy & Paste"
         },
+        storageTips: {
+            label: "Storage tips",
+            hint: "Tap the ⓘ next to an ingredient",
+            iconAriaLabel: "Storage tip",
+            popoverTitle: "Storage tip",
+            loading: "Fetching storage tip…",
+        },
         copyPaste: {
             title: "Copy & Paste",
             description: "Use any AI chat instead of an API key",
@@ -315,6 +322,13 @@ export const translations = {
         modeSwitch: {
             apiKey: "API-Schlüssel",
             copyPaste: "Kopieren & Einfügen"
+        },
+        storageTips: {
+            label: "Lagerungstipps",
+            hint: "Tippe auf das ⓘ neben einer Zutat",
+            iconAriaLabel: "Lagerungstipp",
+            popoverTitle: "Lagerungstipp",
+            loading: "Lade Lagerungstipp…",
         },
         copyPaste: {
             title: "Kopieren & Einfügen",
@@ -527,6 +541,13 @@ export const translations = {
             apiKey: "Clé API",
             copyPaste: "Copier-Coller"
         },
+        storageTips: {
+            label: "Conseils de conservation",
+            hint: "Touchez l'icône ⓘ à côté d'un ingrédient",
+            iconAriaLabel: "Conseil de conservation",
+            popoverTitle: "Conseil de conservation",
+            loading: "Chargement du conseil…",
+        },
         copyPaste: {
             title: "Copier-Coller",
             description: "Utilisez n'importe quel chat IA au lieu d'une clé API",
@@ -737,6 +758,13 @@ export const translations = {
         modeSwitch: {
             apiKey: "Clave API",
             copyPaste: "Copiar y Pegar"
+        },
+        storageTips: {
+            label: "Consejos de conservación",
+            hint: "Toca el ⓘ junto a un ingrediente",
+            iconAriaLabel: "Consejo de conservación",
+            popoverTitle: "Consejo de conservación",
+            loading: "Obteniendo consejo…",
         },
         copyPaste: {
             title: "Copiar y Pegar",

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -71,6 +71,8 @@ interface SettingsContextType {
     setStyleWishes: (wishes: string[]) => void;
     language: string;
     setLanguage: (lang: string) => void;
+    storageTipsEnabled: boolean;
+    setStorageTipsEnabled: (enabled: boolean) => void;
     t: TranslationType;
     storagePersistError: boolean;
 }
@@ -129,8 +131,9 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
     const [diet, setDiet, dietError] = useLocalStorage<string>(STORAGE_KEYS.DIET_PREFERENCE, DEFAULTS.DIET);
     const [styleWishes, setStyleWishes, styleWishesError] = useLocalStorage<string[]>(STORAGE_KEYS.STYLE_WISHES, getInitialStyleWishes());
     const [language, setLanguage, languageError] = useLocalStorage<string>(STORAGE_KEYS.LANGUAGE, getInitialLanguage());
+    const [storageTipsEnabled, setStorageTipsEnabled, storageTipsEnabledError] = useLocalStorage<boolean>(STORAGE_KEYS.STORAGE_TIPS_ENABLED, false);
 
-    const storagePersistError = useCopyPasteError || apiKeyError || peopleError || mealsError || dietError || styleWishesError || languageError;
+    const storagePersistError = useCopyPasteError || apiKeyError || peopleError || mealsError || dietError || styleWishesError || languageError || storageTipsEnabledError;
 
     const t = getTranslations(language);
 
@@ -142,6 +145,7 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
         diet, setDiet,
         styleWishes, setStyleWishes,
         language, setLanguage,
+        storageTipsEnabled, setStorageTipsEnabled,
         t,
         storagePersistError
     };

--- a/src/hooks/useStorageTips.ts
+++ b/src/hooks/useStorageTips.ts
@@ -66,8 +66,9 @@ export function useStorageTips() {
     }, [cache, setCache]);
 
     const restoreAll = useCallback((backup: Record<string, string>) => {
+        setCache(backup);
         writeLocalStorageExternal(STORAGE_KEYS.STORAGE_TIPS_CACHE, backup);
-    }, []);
+    }, [setCache]);
 
     return { getTip, fetchTip, isLoading, getError, clearAll, restoreAll, hasAnyTips };
 }

--- a/src/hooks/useStorageTips.ts
+++ b/src/hooks/useStorageTips.ts
@@ -58,11 +58,12 @@ export function useStorageTips() {
 
     const clearAll = useCallback((): Record<string, string> => {
         const backup = cache;
+        setCache({});
         writeLocalStorageExternal(STORAGE_KEYS.STORAGE_TIPS_CACHE, undefined);
         setErrors({});
         setLoadingKeys(new Set());
         return backup;
-    }, [cache]);
+    }, [cache, setCache]);
 
     const restoreAll = useCallback((backup: Record<string, string>) => {
         writeLocalStorageExternal(STORAGE_KEYS.STORAGE_TIPS_CACHE, backup);

--- a/src/hooks/useStorageTips.ts
+++ b/src/hooks/useStorageTips.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { useLocalStorage } from './useLocalStorage';
+import { useLocalStorage, writeLocalStorageExternal } from './useLocalStorage';
 import { useSettings } from '../contexts/SettingsContext';
 import { fetchStorageTip } from '../services/llm';
 import { STORAGE_KEYS } from '../constants';
@@ -11,6 +11,7 @@ export function useStorageTips() {
     const [cache, setCache] = useLocalStorage<Record<string, string>>(STORAGE_KEYS.STORAGE_TIPS_CACHE, {});
     const [loadingKeys, setLoadingKeys] = useState<Set<string>>(new Set());
     const [errors, setErrors] = useState<Record<string, string>>({});
+    const hasAnyTips = Object.keys(cache).length > 0;
 
     const getTip = useCallback((name: string): string | undefined => {
         return cache[buildKey(language, name)];
@@ -55,5 +56,17 @@ export function useStorageTips() {
         }
     }, [apiKey, language, cache, loadingKeys, setCache, t.errors]);
 
-    return { getTip, fetchTip, isLoading, getError };
+    const clearAll = useCallback((): Record<string, string> => {
+        const backup = cache;
+        writeLocalStorageExternal(STORAGE_KEYS.STORAGE_TIPS_CACHE, undefined);
+        setErrors({});
+        setLoadingKeys(new Set());
+        return backup;
+    }, [cache]);
+
+    const restoreAll = useCallback((backup: Record<string, string>) => {
+        writeLocalStorageExternal(STORAGE_KEYS.STORAGE_TIPS_CACHE, backup);
+    }, []);
+
+    return { getTip, fetchTip, isLoading, getError, clearAll, restoreAll, hasAnyTips };
 }

--- a/src/hooks/useStorageTips.ts
+++ b/src/hooks/useStorageTips.ts
@@ -1,0 +1,59 @@
+import { useCallback, useState } from 'react';
+import { useLocalStorage } from './useLocalStorage';
+import { useSettings } from '../contexts/SettingsContext';
+import { fetchStorageTip } from '../services/llm';
+import { STORAGE_KEYS } from '../constants';
+
+const buildKey = (language: string, name: string) => `${language}:${name.trim().toLowerCase()}`;
+
+export function useStorageTips() {
+    const { apiKey, language, t } = useSettings();
+    const [cache, setCache] = useLocalStorage<Record<string, string>>(STORAGE_KEYS.STORAGE_TIPS_CACHE, {});
+    const [loadingKeys, setLoadingKeys] = useState<Set<string>>(new Set());
+    const [errors, setErrors] = useState<Record<string, string>>({});
+
+    const getTip = useCallback((name: string): string | undefined => {
+        return cache[buildKey(language, name)];
+    }, [cache, language]);
+
+    const isLoading = useCallback((name: string): boolean => {
+        return loadingKeys.has(buildKey(language, name));
+    }, [loadingKeys, language]);
+
+    const getError = useCallback((name: string): string | undefined => {
+        return errors[buildKey(language, name)];
+    }, [errors, language]);
+
+    const fetchTip = useCallback(async (name: string): Promise<void> => {
+        const key = buildKey(language, name);
+        if (cache[key] || loadingKeys.has(key)) return;
+
+        setLoadingKeys(prev => {
+            const next = new Set(prev);
+            next.add(key);
+            return next;
+        });
+        setErrors(prev => {
+            if (!(key in prev)) return prev;
+            const next = { ...prev };
+            delete next[key];
+            return next;
+        });
+
+        try {
+            const tip = await fetchStorageTip(apiKey, name, language, t.errors);
+            setCache(prev => ({ ...prev, [key]: tip }));
+        } catch (err) {
+            const message = err instanceof Error ? err.message : t.errors.unexpectedError;
+            setErrors(prev => ({ ...prev, [key]: message }));
+        } finally {
+            setLoadingKeys(prev => {
+                const next = new Set(prev);
+                next.delete(key);
+                return next;
+            });
+        }
+    }, [apiKey, language, cache, loadingKeys, setCache, t.errors]);
+
+    return { getTip, fetchTip, isLoading, getError };
+}

--- a/src/hooks/useStorageTips.ts
+++ b/src/hooks/useStorageTips.ts
@@ -11,7 +11,7 @@ export function useStorageTips() {
     const [cache, setCache] = useLocalStorage<Record<string, string>>(STORAGE_KEYS.STORAGE_TIPS_CACHE, {});
     const [loadingKeys, setLoadingKeys] = useState<Set<string>>(new Set());
     const [errors, setErrors] = useState<Record<string, string>>({});
-    const hasAnyTips = Object.keys(cache).length > 0;
+    const hasAnyTips = Object.keys(cache || {}).length > 0;
 
     const getTip = useCallback((name: string): string | undefined => {
         return cache[buildKey(language, name)];

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -309,6 +309,70 @@ export const parseRecipeResponse = (text: string, errorTranslations?: ErrorTrans
   }
 };
 
+export const fetchStorageTip = async (
+  apiKey: string,
+  ingredientName: string,
+  language: string,
+  errorTranslations?: ErrorTranslations
+): Promise<string> => {
+  const errors = errorTranslations ?? translations.English.errors;
+
+  if (!apiKey) throw new Error(errors.apiKeyRequired);
+
+  const sanitized = sanitizeUserInput(ingredientName, 100);
+  if (!sanitized) throw new Error(errors.unexpectedError);
+
+  const prompt = `Provide concise, practical storage advice for the ingredient: "${sanitized}".
+
+  RULES:
+  - 1-3 short sentences in plain prose. No lists, headings, markdown, JSON, or quotes around the response.
+  - Cover where to store it (room temperature, fridge, freezer, etc.), expected shelf life when stored well, and a brief tip if relevant (e.g. "keep dry", "wrap in paper", "don't store next to apples").
+  - Output the response in ${language}.
+  - When addressing the reader in a language with a T-V distinction, ALWAYS use the informal second person singular: "du" in German, "tu" in French, "tú" in Spanish. Never use the formal form ("Sie", "vous", "usted").
+  - Output ONLY the storage advice text — no preamble, no labels, no quotation marks.`;
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), API_CONFIG.TIMEOUT_MS);
+
+    const response = await fetch(
+      `${API_CONFIG.BASE_URL}/${API_CONFIG.MODEL}:generateContent?key=${apiKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+        }),
+        signal: controller.signal,
+      }
+    );
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.error?.message || errors.fetchFailed);
+    }
+
+    const data = await response.json();
+    const text: string | undefined = data.candidates?.[0]?.content?.parts?.[0]?.text;
+
+    if (!text) throw new Error(errors.emptyResponse);
+
+    return text.trim().replace(/^["']+|["']+$/g, '').trim();
+  } catch (error) {
+    console.error("Storage tip error:", error);
+
+    if (error instanceof Error) {
+      if (error.name === 'AbortError') throw new Error(errors.timeout);
+      if (error.message.includes('Failed to fetch')) throw new Error(errors.networkError);
+      throw error;
+    }
+
+    throw new Error(errors.unexpectedError);
+  }
+};
+
 export const generateRecipes = async (
   apiKey: string,
   ingredients: PantryItem[],


### PR DESCRIPTION
## Summary
- New opt-in toggle in the header (API mode only) that turns each pantry item's green bullet into a clickable info button.
- Click fetches a 1–3 sentence storage tip from Gemini in the user's language and shows it in an anchored popover; tips are cached in localStorage per `(language, ingredient)` so re-opens are instant and language switches don't re-spend tokens.
- Prompt pins the informal second person (`du` / `tu` / `tú`) so German/French/Spanish tips stay consistent across calls; English passes through unchanged.

## UI notes
- Toggle hidden in Copy & Paste mode (no live LLM available); the bullet renders exactly as before when off.
- Bullet states when on: outlined info icon (uncached) → spinner (loading) → ringed/filled (cached).
- Popover uses an opaque surface (not `glass-panel`) so text stays readable when content sits behind it.
- PantryInput root gets `relative z-20` so the popover can rise above the sibling Spice Rack / Kitchen Appliances panels (each `glass-panel` creates its own stacking context via `backdrop-filter`).

## Test plan
- [ ] In API mode, toggle on → confirm helper text appears and bullets become info buttons.
- [ ] Click a fresh ingredient → spinner → tip renders → reopening is instant.
- [ ] Switch language → previously-fetched tips re-fetch in the new language; old-language tips remain cached.
- [ ] German / French / Spanish tips consistently use `du` / `tu` / `tú`, never the formal form.
- [ ] Toggle off → bullets revert; cache survives in localStorage.
- [ ] Switch to Copy & Paste mode → toggle disappears, no info icons rendered.
- [ ] Popover overlaps Spice Rack panel cleanly (no clipping, readable text).