### PR TITLE
fix(llm): preserve caught error as cause when re-throwing

### DIFF
--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -305,10 +305,11 @@ export const parseRecipeResponse = (text: string, errorTranslations?: ErrorTrans
       const path = firstError.path.join('.');
       throw new Error(
         `${errors.invalidStructure}: ${firstError.message}${path ? ` at ${path}` : ''}. ` +
-        errors.tryAgain
+        errors.tryAgain,
+        { cause: error }
       );
     }
-    throw new Error(errors.invalidJson);
+    throw new Error(errors.invalidJson, { cause: error });
   }
 };
 
@@ -367,12 +368,12 @@ export const fetchStorageTip = async (
     console.error("Storage tip error:", error);
 
     if (error instanceof Error) {
-      if (error.name === 'AbortError') throw new Error(errors.timeout);
-      if (error.message.includes('Failed to fetch')) throw new Error(errors.networkError);
+      if (error.name === 'AbortError') throw new Error(errors.timeout, { cause: error });
+      if (error.message.includes('Failed to fetch')) throw new Error(errors.networkError, { cause: error });
       throw error;
     }
 
-    throw new Error(errors.unexpectedError);
+    throw new Error(errors.unexpectedError, { cause: error });
   }
 };
 
@@ -467,12 +468,12 @@ export const generateRecipeImage = async (
     console.error('Image generation error:', error);
 
     if (error instanceof Error) {
-      if (error.name === 'AbortError') throw new Error(errors.timeout);
-      if (error.message.includes('Failed to fetch')) throw new Error(errors.networkError);
+      if (error.name === 'AbortError') throw new Error(errors.timeout, { cause: error });
+      if (error.message.includes('Failed to fetch')) throw new Error(errors.networkError, { cause: error });
       throw error;
     }
 
-    throw new Error(errors.unexpectedError);
+    throw new Error(errors.unexpectedError, { cause: error });
   }
 };
 
@@ -547,15 +548,15 @@ export const generateRecipes = async (
       if (error.name === 'AbortError' || error.name === 'TimeoutError') {
         // Preserve AbortError when the caller initiated the cancel; otherwise it's a timeout.
         if (externalSignal?.aborted) throw error;
-        throw new Error(errors.timeout);
+        throw new Error(errors.timeout, { cause: error });
       }
       if (error.message.includes('Failed to fetch')) {
-        throw new Error(errors.networkError);
+        throw new Error(errors.networkError, { cause: error });
       }
       // Re-throw with original message if already a user-friendly error
       throw error;
     }
 
-    throw new Error(errors.unexpectedError);
+    throw new Error(errors.unexpectedError, { cause: error });
   }
 };


### PR DESCRIPTION
## Summary
- Forward the caught error via `{ cause: error }` at all 11 `throw new Error(...)` sites in `src/services/llm.ts` catch blocks
- Unblocks the dev-dependencies bump in [#216](https://github.com/DrDonik/ai-recipe-planner/pull/216): ESLint v10's recommended preset enables `preserve-caught-error`, which flags every one of these sites
- Forward-compatible with the current ESLint v9 — no behavior change, just preserves debugging context on re-throws

## Test plan
- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [ ] Rebase #216 on `main` after merge; confirm CI lint goes green there

🤖 Generated with [Claude Code](https://claude.com/claude-code)