### PR TITLE
diag(pantry): surface decode-vs-API failures for iOS webapp photo

### DIFF
--- a/src/components/PantryInput.tsx
+++ b/src/components/PantryInput.tsx
@@ -150,7 +150,14 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
         identifyAbortRef.current = controller;
 
         try {
-            const { base64, mimeType } = await downscaleImage(file);
+            let base64: string;
+            let mimeType: string;
+            try {
+                ({ base64, mimeType } = await downscaleImage(file));
+            } catch (decodeErr) {
+                const detail = decodeErr instanceof Error ? decodeErr.message : String(decodeErr);
+                throw new IdentifyIngredientError('decode', detail, { cause: decodeErr });
+            }
             const ingredient = await identifyIngredientFromImage(
                 apiKey,
                 base64,
@@ -170,11 +177,19 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                 return;
             }
             const kind = err instanceof IdentifyIngredientError ? err.kind : 'error';
-            const message =
+            const detail = err instanceof Error ? err.message : '';
+            const base =
                 kind === 'unknown' ? t.identifyIngredient.unknown
                 : kind === 'multiple' ? t.identifyIngredient.multiple
                 : kind === 'quota' ? t.identifyIngredient.quotaExceeded
+                : kind === 'decode' ? t.identifyIngredient.decodeFailed
                 : t.identifyIngredient.error;
+            // Append the underlying detail for decode/error so we can diagnose
+            // why iOS standalone (home-screen) webapp mode fails where Safari works.
+            const message =
+                (kind === 'decode' || kind === 'error') && detail
+                    ? `${base} (${detail})`
+                    : base;
             setIdentifyError(message);
             setTimeout(() => nameInputRef.current?.focus(), 0);
         } finally {

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -47,6 +47,7 @@ export const translations = {
             unknown: "Couldn't identify the ingredient — please type it.",
             multiple: "Photo shows multiple ingredients — please photograph one at a time.",
             error: "Couldn't identify the photo. Please try again or type it.",
+            decodeFailed: "Couldn't read the photo on this device.",
             quotaExceeded: "Photo identification quota exceeded. Please try again later.",
         },
         photoPrivacy: {
@@ -296,6 +297,7 @@ export const translations = {
             unknown: "Zutat konnte nicht erkannt werden — bitte tippe sie ein.",
             multiple: "Das Foto zeigt mehrere Zutaten — bitte fotografiere jeweils nur eine.",
             error: "Foto konnte nicht ausgewertet werden. Bitte erneut versuchen oder eintippen.",
+            decodeFailed: "Das Foto konnte auf diesem Gerät nicht gelesen werden.",
             quotaExceeded: "Kontingent für die Foto-Erkennung erschöpft. Bitte später erneut versuchen.",
         },
         photoPrivacy: {
@@ -545,6 +547,7 @@ export const translations = {
             unknown: "Impossible d'identifier l'ingrédient — veuillez le saisir.",
             multiple: "La photo contient plusieurs ingrédients — veuillez les photographier un par un.",
             error: "Impossible d'analyser la photo. Veuillez réessayer ou saisir l'ingrédient.",
+            decodeFailed: "Impossible de lire la photo sur cet appareil.",
             quotaExceeded: "Quota d'identification par photo dépassé. Veuillez réessayer plus tard.",
         },
         photoPrivacy: {
@@ -794,6 +797,7 @@ export const translations = {
             unknown: "No se pudo identificar el ingrediente — por favor escríbelo.",
             multiple: "La foto contiene varios ingredientes — por favor fotografía uno a la vez.",
             error: "No se pudo analizar la foto. Por favor, inténtalo de nuevo o escríbelo.",
+            decodeFailed: "No se pudo leer la foto en este dispositivo.",
             quotaExceeded: "Cuota de identificación por foto agotada. Por favor, inténtalo más tarde.",
         },
         photoPrivacy: {

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -477,7 +477,7 @@ export const generateRecipeImage = async (
   }
 };
 
-export type IdentifyIngredientErrorKind = 'unknown' | 'multiple' | 'quota' | 'error';
+export type IdentifyIngredientErrorKind = 'unknown' | 'multiple' | 'quota' | 'decode' | 'error';
 
 export class IdentifyIngredientError extends Error {
   kind: IdentifyIngredientErrorKind;

--- a/src/utils/imageDownscale.ts
+++ b/src/utils/imageDownscale.ts
@@ -46,7 +46,7 @@ export const downscaleImage = async (
   const commaIdx = encoded.indexOf(',');
   // `toDataURL` can return `'data:,'` (empty payload) on iOS for HEIC-sourced
   // canvases; treat that as a decode failure instead of POSTing empty bytes.
-  if (commaIdx < 0 || encoded.length - commaIdx <= 1) {
+  if (commaIdx < 0 || commaIdx === encoded.length - 1) {
     throw new Error(`empty data URL from canvas (type=${file.type || 'unknown'}, ${width}x${height})`);
   }
   const base64 = encoded.slice(commaIdx + 1);

--- a/src/utils/imageDownscale.ts
+++ b/src/utils/imageDownscale.ts
@@ -18,9 +18,16 @@ export const downscaleImage = async (
   const img = await new Promise<HTMLImageElement>((resolve, reject) => {
     const el = new Image();
     el.onload = () => resolve(el);
-    el.onerror = () => reject(new Error('Failed to decode image'));
+    el.onerror = () => reject(new Error(`failed to decode image (type=${file.type || 'unknown'}, size=${file.size})`));
     el.src = objectUrl;
   }).finally(() => URL.revokeObjectURL(objectUrl));
+
+  // iOS in standalone (home-screen) mode sometimes hands over a HEIC original
+  // that decodes to zero dimensions; catch this explicitly so the caller can
+  // distinguish a decode failure from a network/API failure.
+  if (!img.width || !img.height) {
+    throw new Error(`zero-dimension image (type=${file.type || 'unknown'}, size=${file.size})`);
+  }
 
   const longEdge = Math.max(img.width, img.height);
   const scale = longEdge > maxDim ? maxDim / longEdge : 1;
@@ -36,7 +43,12 @@ export const downscaleImage = async (
 
   const mimeType = 'image/jpeg';
   const encoded = canvas.toDataURL(mimeType, quality);
-  // Strip the `data:image/jpeg;base64,` prefix.
-  const base64 = encoded.slice(encoded.indexOf(',') + 1);
+  const commaIdx = encoded.indexOf(',');
+  // `toDataURL` can return `'data:,'` (empty payload) on iOS for HEIC-sourced
+  // canvases; treat that as a decode failure instead of POSTing empty bytes.
+  if (commaIdx < 0 || encoded.length - commaIdx <= 1) {
+    throw new Error(`empty data URL from canvas (type=${file.type || 'unknown'}, ${width}x${height})`);
+  }
+  const base64 = encoded.slice(commaIdx + 1);
   return { base64, mimeType };
 };


### PR DESCRIPTION
## Summary

When the recipe planner is launched from the iOS home screen (standalone webapp mode), photo ingredient recognition fails with the generic *"Couldn't identify the photo"* message — the same recognition works fine in Safari on the same phone. The current `handlePhotoSelected` collapses every non-`unknown`/`multiple`/`quota` failure into a single `error` kind, so we can't tell whether it's the local image decode/canvas step or the API call that's breaking.

This PR is **diagnostic only** — it does not change the Safari-working path. It makes the iOS webapp failure mode observable so we can pick the right fix next.

### Background — why iOS webapp differs from Safari

Investigation across the code and online sources points at three iOS-specific differences between Safari and a home-screen ("Add to Home Screen") standalone webview, all of which can hit our pipeline (`<input type=file capture=environment>` → `URL.createObjectURL` → `<img>` → `<canvas>` → `toDataURL` → Gemini):

- The standalone webview is more likely to deliver the original **HEIC** file from the photo library (Safari more reliably converts to JPEG). HEIC may then fail in `<img>.onerror`, decode to **zero dimensions**, or yield an **empty `toDataURL()`** output.
- `capture="environment"` is sometimes ignored in standalone mode, which routes users to the photo library (more chance of HEIC).
- Camera-related WebKit quirks in standalone PWAs (long-running [WebKit 185448](https://bugs.webkit.org/show_bug.cgi?id=185448), and a transient iOS 18.1 regression).

The project has no `manifest.json`/service worker, so "webapp" here = iOS's home-screen standalone webview, not a full PWA — but the standalone-mode quirks above still apply.

### Changes

- `src/services/llm.ts` — add `'decode'` to `IdentifyIngredientErrorKind`.
- `src/utils/imageDownscale.ts`:
  - `<img>.onerror` now reports `file.type` and `file.size`.
  - Throws explicitly on zero-dimension decoded images.
  - Throws explicitly when `canvas.toDataURL()` returns `data:,` (empty payload) — known iOS HEIC-on-canvas symptom.
- `src/components/PantryInput.tsx` — wrap the `downscaleImage` call so failures throw `IdentifyIngredientError('decode', detail)`. For both `decode` and generic `error` kinds, the displayed message now appends the underlying detail in parentheses.
- `src/constants/translations.ts` — `decodeFailed` strings in EN/DE/ES/FR.

After this change, on the iOS home-screen webapp the user will see one of:

- *"Couldn't read the photo on this device. (failed to decode image (type=image/heic, size=…))"*
- *"Couldn't read the photo on this device. (zero-dimension image (type=image/heic, size=…))"*
- *"Couldn't read the photo on this device. (empty data URL from canvas (type=image/heic, 1024x768))"*
- *"Couldn't identify the photo… (Failed to fetch)"* — would point at network/CSP instead of decode.

That tells us exactly which iOS quirk is biting and what the next fix should be (most likely: try `createImageBitmap(file)` first, fall back to current path; or send raw bytes when downscale fails).

## Test plan

- [ ] `npx tsc --noEmit` — passes (verified locally).
- [ ] `npx eslint src/components/PantryInput.tsx src/utils/imageDownscale.ts src/services/llm.ts src/constants/translations.ts` — passes (verified locally).
- [ ] Manual: Safari on iOS — photo recognition still works as before (no regression in the success path or error categories).
- [ ] Manual: Home-screen webapp on iOS — repro the failure and capture the new specific error string. Report it back so we can land the targeted fix.
- [ ] Manual: desktop Chrome — JPEG photo still recognized; corrupting the file triggers the new `decodeFailed` text with detail.

https://claude.ai/code/session_01GAVW99Wvt3WA2eBnUTStLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAVW99Wvt3WA2eBnUTStLm)_