### PR TITLE
fix(llm): prefer dominant ingredient over MULTIPLE in photo identify

### DIFF
--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -507,8 +507,8 @@ export const identifyIngredientFromImage = async (
 
 Look at the photo and respond with EXACTLY ONE of:
 
-1. The name of the ingredient, in ${language}, with no extra words, punctuation, quantity, or description. Just the name.
-2. The exact token MULTIPLE — if the photo clearly shows two or more distinct food ingredients (e.g. an onion and a tomato together). Ignore incidental items like hands, plates, cutting boards, or packaging — those don't count as ingredients.
+1. The name of the most prominent ingredient, in ${language}, with no extra words, punctuation, quantity, or description. Just the name. If one ingredient is clearly the main subject (centered, in focus, or taking up most of the frame), name that one — even if other ingredients are partly visible at the edges or in the background.
+2. The exact token MULTIPLE — only if two or more distinct food ingredients share the focus roughly equally and no single one stands out as the main subject. Ignore incidental items like hands, plates, cutting boards, or packaging — those don't count as ingredients.
 3. The exact token UNKNOWN — if you cannot confidently identify the ingredient, the photo is unclear, or it does not show food.
 
 Respond with only one line. No explanation.`;


### PR DESCRIPTION
## Summary

Photo mode in pantry input was returning `MULTIPLE` whenever a second ingredient peeked in at the edge of the frame, even when the main subject was clearly centered and dominant.

The vision prompt in `src/services/llm.ts` is reworded so that:
- Option 1 explicitly asks for the **most prominent** ingredient and accepts photos where other items are partly visible at the edges/background.
- `MULTIPLE` only fires when two or more ingredients share the focus roughly equally with no clear main subject.

## Test plan

- [ ] Take a photo with one main ingredient centered and a second ingredient partially visible at the edge → should identify the main one (previously returned `MULTIPLE`).
- [ ] Photo with two ingredients sharing focus equally → still returns `MULTIPLE`.
- [ ] Unclear / non-food photo → still returns `UNKNOWN`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014KzyY3k7qwuhJayJvHpzZG)_