### PR TITLE
refactor(header): drop storage tips toggle, gate tips on api key

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, Info, Trash2 } from 'lucide-react';
+import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, Trash2 } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { useStorageTips } from '../hooks/useStorageTips';
 import { API_CONFIG, STORAGE_KEYS } from '../constants';
@@ -28,7 +28,7 @@ export const Header: React.FC<HeaderProps> = ({
     onClearNotification,
     syncStatus,
 }) => {
-    const { useCopyPaste, setUseCopyPaste, apiKey, setApiKey, language, setLanguage, storageTipsEnabled, setStorageTipsEnabled, t } = useSettings();
+    const { useCopyPaste, setUseCopyPaste, apiKey, setApiKey, language, setLanguage, t } = useSettings();
     const { clearAll: clearAllStorageTips, restoreAll: restoreAllStorageTips, hasAnyTips: hasAnyStorageTips } = useStorageTips();
 
     // Check on mount if existing user needs to see the security warning
@@ -325,40 +325,16 @@ export const Header: React.FC<HeaderProps> = ({
                                 </div>
                             )}
 
-                            {!useCopyPaste && (
-                                <div className="flex flex-col gap-1 animate-in fade-in slide-in-from-top-2 duration-300">
-                                    <div className="flex items-center gap-2">
-                                        <Info size={16} className="text-text-muted" aria-hidden="true" />
-                                        <span className={`text-sm transition-colors ${storageTipsEnabled ? 'text-text-main font-medium' : 'text-text-muted'}`}>
-                                            {t.storageTips.label}
-                                        </span>
-                                        <button
-                                            onClick={() => setStorageTipsEnabled(!storageTipsEnabled)}
-                                            className="relative w-12 h-6 bg-white/50 dark:bg-black/30 rounded-full border border-[var(--glass-border)] transition-colors hover:bg-white/70 dark:hover:bg-black/40"
-                                            role="switch"
-                                            aria-checked={storageTipsEnabled}
-                                            aria-label={t.storageTips.label}
-                                        >
-                                            <span
-                                                className={`absolute top-0.5 w-5 h-5 bg-primary rounded-full shadow-md transition-all duration-200 ${storageTipsEnabled ? 'left-6' : 'left-0.5'}`}
-                                            />
-                                        </button>
-                                        {hasAnyStorageTips && (
-                                            <TooltipButton
-                                                icon={<Trash2 size={14} />}
-                                                tooltip={t.storageTips.clearAll}
-                                                ariaLabel={t.storageTips.clearAll}
-                                                className="!p-1.5 cursor-pointer hover:!text-red-500 hover:!bg-red-500/10"
-                                                onClick={handleClearStorageTips}
-                                            />
-                                        )}
-                                    </div>
-                                    {storageTipsEnabled && (
-                                        <span className="text-xs text-text-muted flex items-center gap-1 pl-6">
-                                            <Info size={12} aria-hidden="true" />
-                                            {t.storageTips.hint}
-                                        </span>
-                                    )}
+                            {!useCopyPaste && hasAnyStorageTips && (
+                                <div className="flex items-center gap-2 animate-in fade-in slide-in-from-top-2 duration-300">
+                                    <span className="text-sm text-text-muted">{t.storageTips.label}</span>
+                                    <TooltipButton
+                                        icon={<Trash2 size={14} />}
+                                        tooltip={t.storageTips.clearAll}
+                                        ariaLabel={t.storageTips.clearAll}
+                                        className="!p-1.5 cursor-pointer hover:!text-red-500 hover:!bg-red-500/10"
+                                        onClick={handleClearStorageTips}
+                                    />
                                 </div>
                             )}
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, Trash2 } from 'lucide-react';
+import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, Info, Trash2 } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { useStorageTips } from '../hooks/useStorageTips';
 import { API_CONFIG, STORAGE_KEYS } from '../constants';
@@ -327,6 +327,7 @@ export const Header: React.FC<HeaderProps> = ({
 
                             {!useCopyPaste && hasAnyStorageTips && (
                                 <div className="flex items-center gap-2 animate-in fade-in slide-in-from-top-2 duration-300">
+                                    <Info size={16} className="text-text-muted" aria-hidden="true" />
                                     <span className="text-sm text-text-muted">{t.storageTips.label}</span>
                                     <TooltipButton
                                         icon={<Trash2 size={14} />}

--- a/src/components/PantryInput.tsx
+++ b/src/components/PantryInput.tsx
@@ -34,8 +34,8 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
     isMinimized,
     onToggleMinimize
 }, ref) => {
-    const { t, useCopyPaste, storageTipsEnabled, apiKey, language } = useSettings();
-    const tipsActive = storageTipsEnabled && !useCopyPaste;
+    const { t, useCopyPaste, apiKey, language } = useSettings();
+    const tipsActive = !useCopyPaste && !!apiKey;
     const cameraEnabled = !useCopyPaste && !!apiKey;
     const { getTip, fetchTip, isLoading: isTipLoading, getError: getTipError } = useStorageTips();
     const [name, setName] = useState('');

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -33,7 +33,6 @@ export const STORAGE_KEYS = {
     GIST_ID: 'gist_sync_id',
     SYNC_UPDATED_AT: 'sync_updated_at',
     GIST_TOKEN_WARNING_SEEN: 'gist_token_warning_seen',
-    STORAGE_TIPS_ENABLED: 'storage_tips_enabled',
     STORAGE_TIPS_CACHE: 'storage_tips_cache',
     PHOTO_PRIVACY_ACK: 'photo_privacy_ack',
 } as const;

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -135,7 +135,6 @@ export const translations = {
         },
         storageTips: {
             label: "Storage tips",
-            hint: "Tap the ⓘ next to an ingredient",
             iconAriaLabel: "Storage tip",
             popoverTitle: "Storage tip",
             loading: "Fetching storage tip…",
@@ -385,7 +384,6 @@ export const translations = {
         },
         storageTips: {
             label: "Lagerungstipps",
-            hint: "Tippe auf das ⓘ neben einer Zutat",
             iconAriaLabel: "Lagerungstipp",
             popoverTitle: "Lagerungstipp",
             loading: "Lade Lagerungstipp…",
@@ -635,7 +633,6 @@ export const translations = {
         },
         storageTips: {
             label: "Conseils de conservation",
-            hint: "Touchez l'icône ⓘ à côté d'un ingrédient",
             iconAriaLabel: "Conseil de conservation",
             popoverTitle: "Conseil de conservation",
             loading: "Chargement du conseil…",
@@ -885,7 +882,6 @@ export const translations = {
         },
         storageTips: {
             label: "Consejos de conservación",
-            hint: "Toca el ⓘ junto a un ingrediente",
             iconAriaLabel: "Consejo de conservación",
             popoverTitle: "Consejo de conservación",
             loading: "Obteniendo consejo…",

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -71,8 +71,6 @@ interface SettingsContextType {
     setStyleWishes: (wishes: string[]) => void;
     language: string;
     setLanguage: (lang: string) => void;
-    storageTipsEnabled: boolean;
-    setStorageTipsEnabled: (enabled: boolean) => void;
     t: TranslationType;
     storagePersistError: boolean;
 }
@@ -131,9 +129,8 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
     const [diet, setDiet, dietError] = useLocalStorage<string>(STORAGE_KEYS.DIET_PREFERENCE, DEFAULTS.DIET);
     const [styleWishes, setStyleWishes, styleWishesError] = useLocalStorage<string[]>(STORAGE_KEYS.STYLE_WISHES, getInitialStyleWishes());
     const [language, setLanguage, languageError] = useLocalStorage<string>(STORAGE_KEYS.LANGUAGE, getInitialLanguage());
-    const [storageTipsEnabled, setStorageTipsEnabled, storageTipsEnabledError] = useLocalStorage<boolean>(STORAGE_KEYS.STORAGE_TIPS_ENABLED, false);
 
-    const storagePersistError = useCopyPasteError || apiKeyError || peopleError || mealsError || dietError || styleWishesError || languageError || storageTipsEnabledError;
+    const storagePersistError = useCopyPasteError || apiKeyError || peopleError || mealsError || dietError || styleWishesError || languageError;
 
     const t = getTranslations(language);
 
@@ -145,7 +142,6 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
         diet, setDiet,
         styleWishes, setStyleWishes,
         language, setLanguage,
-        storageTipsEnabled, setStorageTipsEnabled,
         t,
         storagePersistError
     };


### PR DESCRIPTION
## Summary
- Remove the "Storage tips" on/off switch from the header — the feature is opt-in by clicking the ⓘ next to an ingredient anyway, so the toggle was an unnecessary extra step.
- Activate storage tips whenever the API key is set (`tipsActive = !useCopyPaste && !!apiKey`), matching how the camera-identify feature already works.
- Keep the "Clear all storage tips" button in the header but only render it when there are cached tips.
- Drop the now-unused `storageTipsEnabled` state from `SettingsContext`, the `STORAGE_TIPS_ENABLED` localStorage key, and the `storageTips.hint` translation entries.

## Test plan
- [ ] In API Key mode with a key set, ingredient rows in the pantry render the ⓘ button and clicking it fetches a storage tip
- [ ] In API Key mode with no key set, the ⓘ button does not appear (only the bullet) since `tipsActive` requires an API key
- [ ] In Copy & Paste mode, the storage-tips UI is hidden everywhere (header row + pantry icons)
- [ ] After fetching at least one tip, the "Clear all storage tips" trash button appears in the header next to the "Storage tips" label, and clicking it clears the cache with an undo notification
- [ ] All four languages (English/German/Spanish/French) render without missing-translation warnings
- [ ] `npm run build` and `npm run lint` succeed

https://claude.ai/code/session_016PkaVcNBTjyHWdYLe91RxE

---
_Generated by [Claude Code](https://claude.ai/code/session_016PkaVcNBTjyHWdYLe91RxE)_