### PR TITLE
refactor(header): remove storage tips clear cluster

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useRef } from 'react';
-import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, Info, Trash2 } from 'lucide-react';
+import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2 } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
-import { useStorageTips } from '../hooks/useStorageTips';
 import { API_CONFIG, STORAGE_KEYS } from '../constants';
 import { ApiKeySecurityDialog } from './ApiKeySecurityDialog';
 import { ClearApiKeyDialog } from './ClearApiKeyDialog';
@@ -29,7 +28,6 @@ export const Header: React.FC<HeaderProps> = ({
     syncStatus,
 }) => {
     const { useCopyPaste, setUseCopyPaste, apiKey, setApiKey, language, setLanguage, t } = useSettings();
-    const { clearAll: clearAllStorageTips, restoreAll: restoreAllStorageTips, hasAnyTips: hasAnyStorageTips } = useStorageTips();
 
     // Check on mount if existing user needs to see the security warning
     const [showSecurityDialog, setShowSecurityDialog] = useState(() => {
@@ -188,23 +186,6 @@ export const Header: React.FC<HeaderProps> = ({
         setPendingModeSwitch(null);
     };
 
-    const handleClearStorageTips = () => {
-        const backup = clearAllStorageTips();
-        onShowNotification({
-            message: t.undo.storageTipsCleared,
-            type: 'undo',
-            action: {
-                label: t.undo.action,
-                ariaLabel: `${t.undo.action} ${t.undo.storageTipsCleared.toLowerCase()}`,
-                onClick: () => {
-                    restoreAllStorageTips(backup);
-                    onClearNotification();
-                }
-            },
-            timeout: 5000
-        });
-    };
-
     return (
         <>
         <header className={`glass-panel !py-2 rounded-none border-x-0 border-t-0 sticky top-0 z-50 mb-4 backdrop-blur-xl transition-all duration-300 ${headerMinimized ? '!py-1' : ''}`}>
@@ -322,20 +303,6 @@ export const Header: React.FC<HeaderProps> = ({
                                     >
                                         <ExternalLink size={14} />
                                     </a>
-                                </div>
-                            )}
-
-                            {!useCopyPaste && hasAnyStorageTips && (
-                                <div className="flex items-center gap-2 animate-in fade-in slide-in-from-top-2 duration-300">
-                                    <Info size={16} className="text-text-muted" aria-hidden="true" />
-                                    <span className="text-sm text-text-muted">{t.storageTips.label}</span>
-                                    <TooltipButton
-                                        icon={<Trash2 size={14} />}
-                                        tooltip={t.storageTips.clearAll}
-                                        ariaLabel={t.storageTips.clearAll}
-                                        className="!p-1.5 cursor-pointer hover:!text-red-500 hover:!bg-red-500/10"
-                                        onClick={handleClearStorageTips}
-                                    />
                                 </div>
                             )}
 

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -134,12 +134,10 @@ export const translations = {
             copyPaste: "Copy & Paste"
         },
         storageTips: {
-            label: "Storage tips",
             iconAriaLabel: "Storage tip",
             popoverTitle: "Storage tip",
             loading: "Fetching storage tip…",
             close: "Close",
-            clearAll: "Clear all storage tips",
         },
         copyPaste: {
             title: "Copy & Paste",
@@ -187,7 +185,6 @@ export const translations = {
             pantryEmptied: "Pantry emptied",
             recipeDeleted: "Recipe deleted",
             apiKeyCleared: "API key cleared",
-            storageTipsCleared: "Storage tips cleared",
             mealPlanReplaced: "New meal plan created",
             action: "Undo"
         },
@@ -383,12 +380,10 @@ export const translations = {
             copyPaste: "Kopieren & Einfügen"
         },
         storageTips: {
-            label: "Lagerungstipps",
             iconAriaLabel: "Lagerungstipp",
             popoverTitle: "Lagerungstipp",
             loading: "Lade Lagerungstipp…",
             close: "Schließen",
-            clearAll: "Alle Lagerungstipps löschen",
         },
         copyPaste: {
             title: "Kopieren & Einfügen",
@@ -436,7 +431,6 @@ export const translations = {
             pantryEmptied: "Vorrat geleert",
             recipeDeleted: "Rezept gelöscht",
             apiKeyCleared: "API-Schlüssel gelöscht",
-            storageTipsCleared: "Lagerungstipps gelöscht",
             mealPlanReplaced: "Neuer Menüplan erstellt",
             action: "Rückgängig"
         },
@@ -632,12 +626,10 @@ export const translations = {
             copyPaste: "Copier-Coller"
         },
         storageTips: {
-            label: "Conseils de conservation",
             iconAriaLabel: "Conseil de conservation",
             popoverTitle: "Conseil de conservation",
             loading: "Chargement du conseil…",
             close: "Fermer",
-            clearAll: "Effacer tous les conseils de conservation",
         },
         copyPaste: {
             title: "Copier-Coller",
@@ -685,7 +677,6 @@ export const translations = {
             pantryEmptied: "Garde-manger vidé",
             recipeDeleted: "Recette supprimée",
             apiKeyCleared: "Clé API effacée",
-            storageTipsCleared: "Conseils de conservation effacés",
             mealPlanReplaced: "Nouveau plan de repas créé",
             action: "Annuler"
         },
@@ -881,12 +872,10 @@ export const translations = {
             copyPaste: "Copiar y Pegar"
         },
         storageTips: {
-            label: "Consejos de conservación",
             iconAriaLabel: "Consejo de conservación",
             popoverTitle: "Consejo de conservación",
             loading: "Obteniendo consejo…",
             close: "Cerrar",
-            clearAll: "Eliminar todos los consejos de conservación",
         },
         copyPaste: {
             title: "Copiar y Pegar",
@@ -934,7 +923,6 @@ export const translations = {
             pantryEmptied: "Despensa vaciada",
             recipeDeleted: "Receta eliminada",
             apiKeyCleared: "Clave API eliminada",
-            storageTipsCleared: "Consejos de conservación eliminados",
             mealPlanReplaced: "Nuevo plan de comidas creado",
             action: "Deshacer"
         },

--- a/src/hooks/useStorageTips.ts
+++ b/src/hooks/useStorageTips.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { useLocalStorage, writeLocalStorageExternal } from './useLocalStorage';
+import { useLocalStorage } from './useLocalStorage';
 import { useSettings } from '../contexts/SettingsContext';
 import { fetchStorageTip } from '../services/llm';
 import { STORAGE_KEYS } from '../constants';
@@ -11,7 +11,6 @@ export function useStorageTips() {
     const [cache, setCache] = useLocalStorage<Record<string, string>>(STORAGE_KEYS.STORAGE_TIPS_CACHE, {});
     const [loadingKeys, setLoadingKeys] = useState<Set<string>>(new Set());
     const [errors, setErrors] = useState<Record<string, string>>({});
-    const hasAnyTips = Object.keys(cache || {}).length > 0;
 
     const getTip = useCallback((name: string): string | undefined => {
         return cache[buildKey(language, name)];
@@ -56,19 +55,5 @@ export function useStorageTips() {
         }
     }, [apiKey, language, cache, loadingKeys, setCache, t.errors]);
 
-    const clearAll = useCallback((): Record<string, string> => {
-        const backup = cache;
-        setCache({});
-        writeLocalStorageExternal(STORAGE_KEYS.STORAGE_TIPS_CACHE, undefined);
-        setErrors({});
-        setLoadingKeys(new Set());
-        return backup;
-    }, [cache, setCache]);
-
-    const restoreAll = useCallback((backup: Record<string, string>) => {
-        setCache(backup);
-        writeLocalStorageExternal(STORAGE_KEYS.STORAGE_TIPS_CACHE, backup);
-    }, [setCache]);
-
-    return { getTip, fetchTip, isLoading, getError, clearAll, restoreAll, hasAnyTips };
+    return { getTip, fetchTip, isLoading, getError };
 }


### PR DESCRIPTION
## Summary
- Remove the conditional Info/Trash2 cluster from the header that let users bulk-clear cached storage tips
- Drop the now-unused `clearAll`/`restoreAll`/`hasAnyTips` from `useStorageTips`, plus `storageTips.label`, `storageTips.clearAll`, and `undo.storageTipsCleared` keys across all four languages
- Storage-tip popover (icon, title, loading, close) is unchanged — only the bulk-clear UI and undo plumbing are gone

## Test plan
- [ ] Header renders cleanly in both API-key and Copy & Paste modes with no leftover gap where the cluster used to be
- [ ] Open a pantry item's storage tip popover — fetch, display, and close still work
- [ ] Switch language while a tip is cached — popover content still resolves correctly
- [ ] `npx tsc --noEmit` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)