### PR TITLE
feat(shopping-list): add clear button with undo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { WelcomeDialog } from './components/WelcomeDialog';
 import { CopyPasteDialog } from './components/CopyPasteDialog';
 import { generateRecipes, buildRecipePrompt, parseRecipeResponse } from './services/llm';
 import type { PantryItem, MealPlan, Recipe, Ingredient, Notification } from './types';
-import { useLocalStorage } from './hooks/useLocalStorage';
+import { useLocalStorage, writeLocalStorageExternal } from './hooks/useLocalStorage';
 import { generateShareUrl } from './utils/sharing';
 import { parseSharedUrlParams } from './utils/sharedUrlParams';
 import { Header } from './components/Header';
@@ -279,6 +279,34 @@ function App() {
       item.id === id ? { ...item, amount: newAmount } : item
     ));
   }, [setPantryItems]);
+
+  const clearShoppingList = useCallback(() => {
+    if (!mealPlan) return;
+    const backupList = mealPlan.shoppingList;
+    const backupCheckedRaw = localStorage.getItem(STORAGE_KEYS.SHOPPING_LIST_CHECKED);
+    setMealPlan({ ...mealPlan, shoppingList: [] });
+    writeLocalStorageExternal(STORAGE_KEYS.SHOPPING_LIST_CHECKED, undefined);
+    showNotification({
+      message: t.undo.shoppingListCleared,
+      type: 'undo',
+      action: {
+        label: t.undo.action,
+        ariaLabel: `${t.undo.action} ${t.undo.shoppingListCleared.toLowerCase()}`,
+        onClick: () => {
+          setMealPlan(prev => prev ? { ...prev, shoppingList: backupList } : prev);
+          if (backupCheckedRaw !== null) {
+            try {
+              writeLocalStorageExternal(STORAGE_KEYS.SHOPPING_LIST_CHECKED, JSON.parse(backupCheckedRaw));
+            } catch {
+              // Malformed backup — skip restoring checked state.
+            }
+          }
+          clearNotification();
+        }
+      },
+      timeout: 5000
+    });
+  }, [mealPlan, setMealPlan, showNotification, clearNotification, t.undo.shoppingListCleared, t.undo.action]);
 
   const emptyPantry = useCallback(() => {
     const backup = [...pantryItems];
@@ -577,6 +605,7 @@ function App() {
                   isMinimized={shoppingListMinimized}
                   onToggleMinimize={handleToggleShoppingListMinimize}
                   onViewSingle={() => openShoppingListView(mealPlan.shoppingList)}
+                  onClear={clearShoppingList}
                   onPersistErrorChange={setShoppingListCheckedPersistError}
                 />
 

--- a/src/components/ShoppingList.tsx
+++ b/src/components/ShoppingList.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback, useState, useEffect } from 'react';
-import { ShoppingCart, ExternalLink, ChevronUp, ChevronDown, Info, X } from 'lucide-react';
+import { ShoppingCart, ExternalLink, ChevronUp, ChevronDown, Info, X, Trash2 } from 'lucide-react';
 import { motion } from 'framer-motion';
 import type { Ingredient, MealPlan } from '../types';
 import { useLocalStorage } from '../hooks/useLocalStorage';
@@ -14,10 +14,11 @@ interface ShoppingListProps {
     isStandaloneView?: boolean;
     onViewSingle?: () => void;
     onClose?: () => void;
+    onClear?: () => void;
     onPersistErrorChange?: (hasError: boolean) => void;
 }
 
-export const ShoppingList: React.FC<ShoppingListProps> = ({ items, isMinimized = false, onToggleMinimize, isStandaloneView = false, onViewSingle, onClose, onPersistErrorChange }) => {
+export const ShoppingList: React.FC<ShoppingListProps> = ({ items, isMinimized = false, onToggleMinimize, isStandaloneView = false, onViewSingle, onClose, onClear, onPersistErrorChange }) => {
     const { t } = useSettings();
 
     // Load checked items from localStorage (used for main view and own list in standalone)
@@ -195,39 +196,53 @@ export const ShoppingList: React.FC<ShoppingListProps> = ({ items, isMinimized =
             </div>
 
             {!isMinimized && (
-                <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 list-none p-0 m-0" role="list">
-                    {items.map((item, i) => {
-                        const itemKey = getItemKey(item);
-                        const isChecked = checkedItems.has(itemKey);
-                        const checkboxId = `shopping-item-${i}`;
-                        return (
-                            <li
-                                key={`${itemKey}-${i}`}
-                                className="flex items-center justify-between bg-white/40 dark:bg-black/20 rounded-lg border border-border-base hover:border-border-hover transition-colors p-3 shadow-sm cursor-pointer"
-                                onClick={(e) => {
-                                    // Avoid double-toggle when clicking the checkbox directly
-                                    if ((e.target as HTMLElement).tagName !== 'INPUT') {
-                                        toggleItem(itemKey);
-                                    }
-                                }}
+                <>
+                    <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 list-none p-0 m-0" role="list">
+                        {items.map((item, i) => {
+                            const itemKey = getItemKey(item);
+                            const isChecked = checkedItems.has(itemKey);
+                            const checkboxId = `shopping-item-${i}`;
+                            return (
+                                <li
+                                    key={`${itemKey}-${i}`}
+                                    className="flex items-center justify-between bg-white/40 dark:bg-black/20 rounded-lg border border-border-base hover:border-border-hover transition-colors p-3 shadow-sm cursor-pointer"
+                                    onClick={(e) => {
+                                        // Avoid double-toggle when clicking the checkbox directly
+                                        if ((e.target as HTMLElement).tagName !== 'INPUT') {
+                                            toggleItem(itemKey);
+                                        }
+                                    }}
+                                >
+                                    <label htmlFor={checkboxId} className="flex items-center gap-3 cursor-pointer flex-1" onClick={(e) => e.stopPropagation()}>
+                                        <input
+                                            id={checkboxId}
+                                            type="checkbox"
+                                            checked={isChecked}
+                                            onChange={() => toggleItem(itemKey)}
+                                            className="w-5 h-5 accent-primary rounded cursor-pointer"
+                                        />
+                                        <span className={`font-medium ${isChecked ? 'line-through text-text-muted' : ''}`}>{item.item}</span>
+                                    </label>
+                                    <span className="text-sm text-text-muted bg-white/50 dark:bg-black/30 rounded text-right px-3 py-1">
+                                        {item.amount}
+                                    </span>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                    {onClear && (
+                        <div className="flex justify-end mt-4">
+                            <button
+                                type="button"
+                                onClick={onClear}
+                                className="text-sm text-text-muted hover:text-red-500 hover:bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5 cursor-pointer"
                             >
-                                <label htmlFor={checkboxId} className="flex items-center gap-3 cursor-pointer flex-1" onClick={(e) => e.stopPropagation()}>
-                                    <input
-                                        id={checkboxId}
-                                        type="checkbox"
-                                        checked={isChecked}
-                                        onChange={() => toggleItem(itemKey)}
-                                        className="w-5 h-5 accent-primary rounded cursor-pointer"
-                                    />
-                                    <span className={`font-medium ${isChecked ? 'line-through text-text-muted' : ''}`}>{item.item}</span>
-                                </label>
-                                <span className="text-sm text-text-muted bg-white/50 dark:bg-black/30 rounded text-right px-3 py-1">
-                                    {item.amount}
-                                </span>
-                            </li>
-                        );
-                    })}
-                </ul>
+                                <Trash2 size={14} />
+                                {t.clearShoppingList}
+                            </button>
+                        </div>
+                    )}
+                </>
             )}
         </motion.div>
     );

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -111,6 +111,7 @@ export const translations = {
             remove: "Remove image",
         },
         emptyPantry: "Empty Pantry",
+        clearShoppingList: "Clear Shopping List",
         nutritionPerServing: "Per serving (estimate)",
         calories: "kcal",
         carbs: "Carbs",
@@ -185,6 +186,7 @@ export const translations = {
         },
         undo: {
             pantryEmptied: "Pantry emptied",
+            shoppingListCleared: "Shopping list cleared",
             recipeDeleted: "Recipe deleted",
             apiKeyCleared: "API key cleared",
             storageTipsCleared: "Storage tips cleared",
@@ -360,6 +362,7 @@ export const translations = {
             remove: "Bild entfernen",
         },
         emptyPantry: "Vorrat leeren",
+        clearShoppingList: "Einkaufsliste leeren",
         nutritionPerServing: "Pro Portion (Schätzung)",
         calories: "kcal",
         carbs: "Kohlenhydrate",
@@ -434,6 +437,7 @@ export const translations = {
         },
         undo: {
             pantryEmptied: "Vorrat geleert",
+            shoppingListCleared: "Einkaufsliste geleert",
             recipeDeleted: "Rezept gelöscht",
             apiKeyCleared: "API-Schlüssel gelöscht",
             storageTipsCleared: "Lagerungstipps gelöscht",
@@ -609,6 +613,7 @@ export const translations = {
             remove: "Supprimer l'image",
         },
         emptyPantry: "Vider le garde-manger",
+        clearShoppingList: "Vider la liste de courses",
         nutritionPerServing: "Par portion (estimation)",
         calories: "kcal",
         carbs: "Glucides",
@@ -683,6 +688,7 @@ export const translations = {
         },
         undo: {
             pantryEmptied: "Garde-manger vidé",
+            shoppingListCleared: "Liste de courses vidée",
             recipeDeleted: "Recette supprimée",
             apiKeyCleared: "Clé API effacée",
             storageTipsCleared: "Conseils de conservation effacés",
@@ -858,6 +864,7 @@ export const translations = {
             remove: "Eliminar imagen",
         },
         emptyPantry: "Vaciar despensa",
+        clearShoppingList: "Vaciar lista de compras",
         nutritionPerServing: "Por porción (estimado)",
         calories: "kcal",
         carbs: "Carbohidratos",
@@ -932,6 +939,7 @@ export const translations = {
         },
         undo: {
             pantryEmptied: "Despensa vaciada",
+            shoppingListCleared: "Lista de compras vaciada",
             recipeDeleted: "Receta eliminada",
             apiKeyCleared: "Clave API eliminada",
             storageTipsCleared: "Consejos de conservación eliminados",


### PR DESCRIPTION
## Summary
- Adds a "Clear Shopping List" link at the bottom-right of the main shopping list panel (mirrors the pantry's "Empty Pantry" affordance — `Trash2` icon, same hover/red styling).
- Empties `mealPlan.shoppingList` and clears the `SHOPPING_LIST_CHECKED` localStorage key; the existing `items.length === 0` guard then hides the panel entirely.
- 5-second undo toast restores both the list items and the checked state.
- Standalone tab and decoupled shared lists do not get the button — clearing someone else's list (or your own from a separate tab) isn't sensible.
- Per-recipe `missingIngredients` chips remain untouched — they're contextual info that's useful even after shopping is done.

## Test plan
- [ ] Generate a meal plan, check several items in the shopping list, click "Clear Shopping List" → panel disappears, toast appears.
- [ ] Click "Undo" within 5s → list and checked items both return.
- [ ] Let toast expire → list stays cleared.
- [ ] Open shopping list in standalone tab (own list) — verify no clear button.
- [ ] Open a shared shopping list URL — verify no clear button (decoupled view).
- [ ] Verify per-recipe "Need to buy" chips are unaffected after clearing.
- [ ] Cycle through all 4 languages (English, German, Spanish, French) and confirm both the button label and the undo toast text render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)