### PR TITLE
feat(image-gen): paid-tier opt-in toggle with free-tier snap-back

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
   const savedScrollPositionRef = useRef<number>(0);
   const prevViewRecipeRef = useRef<Recipe | null>(null);
   const prevViewShoppingListRef = useRef<Ingredient[] | null>(null);
-  const { useCopyPaste, apiKey, people, meals, diet, styleWishes, language, t, storagePersistError } = useSettings();
+  const { useCopyPaste, apiKey, people, meals, diet, styleWishes, language, imageGenEnabled, setImageGenEnabled, t, storagePersistError } = useSettings();
 
   const [pantryItems, setPantryItems, pantryPersistError] = useLocalStorage<PantryItem[]>(STORAGE_KEYS.PANTRY_ITEMS, []);
   const [spices, setSpices, spicesPersistError] = useLocalStorage<string[]>(STORAGE_KEYS.SPICE_RACK, []);
@@ -79,14 +79,6 @@ function App() {
   // Multi-device sync via GitHub Gist (opt-in).
   const sync = useGistSync();
 
-  // On-demand recipe image generation, persisted in IndexedDB.
-  // Image generation requires a configured API key and direct-API mode (the
-  // copy-paste flow has no API call to make). Standalone shared-link views
-  // (no meal plan loaded) also can't generate, since there's nowhere to persist.
-  const recipeIds = useMemo(() => mealPlan?.recipes.map(r => r.id) ?? [], [mealPlan]);
-  const recipeImage = useRecipeImage(recipeIds);
-  const canGenerateImages = !useCopyPaste && !!apiKey;
-
   // Memoized callbacks to prevent unnecessary re-renders
   const handleCloseWelcome = useCallback(() => setShowWelcome(false), []);
   const handleShowHelp = useCallback(() => setShowWelcome(true), []);
@@ -119,6 +111,20 @@ function App() {
     }
     setNotification(null);
   }, []);
+
+  // On-demand recipe image generation, persisted in IndexedDB.
+  // Image generation requires a configured API key, direct-API mode (the
+  // copy-paste flow has no API call to make), and the user-facing toggle
+  // confirming they want to spend money on a paid Gemini tier. Standalone
+  // shared-link views (no meal plan loaded) also can't generate, since
+  // there's nowhere to persist.
+  const recipeIds = useMemo(() => mealPlan?.recipes.map(r => r.id) ?? [], [mealPlan]);
+  const handleFreeTierLimit = useCallback(() => {
+    setImageGenEnabled(false);
+    showNotification({ message: t.errors.imageFreeTierUnsupported, type: 'error', timeout: 5000 });
+  }, [setImageGenEnabled, showNotification, t.errors.imageFreeTierUnsupported]);
+  const recipeImage = useRecipeImage(recipeIds, { onFreeTierLimit: handleFreeTierLimit });
+  const canGenerateImages = !useCopyPaste && !!apiKey && imageGenEnabled;
 
   // Storage error notification — deduplicated via ref guard
   const storageErrorShownRef = useRef(false);
@@ -509,7 +515,7 @@ function App() {
             missingIngredientsMinimized={recipeMissingIngredientsMinimized}
             onToggleMissingIngredientsMinimize={handleToggleRecipeMissingIngredientsMinimize}
             onGenerateImage={canGenerateForView ? () => recipeImage.generate(viewRecipe) : undefined}
-            onRemoveImage={canGenerateForView ? () => recipeImage.remove(viewRecipe.id) : undefined}
+            onRemoveImage={isOwnRecipe ? () => recipeImage.remove(viewRecipe.id) : undefined}
             isImageLoading={recipeImage.isLoading(viewRecipe.id)}
             imageError={recipeImage.getError(viewRecipe.id)}
             imageUrl={recipeImage.getImageUrl(viewRecipe.id)}
@@ -635,7 +641,7 @@ function App() {
                         missingIngredientsMinimized={recipeMissingIngredientsMinimized}
                         onToggleMissingIngredientsMinimize={handleToggleRecipeMissingIngredientsMinimize}
                         onGenerateImage={canGenerateImages ? () => recipeImage.generate(recipe) : undefined}
-                        onRemoveImage={canGenerateImages ? () => recipeImage.remove(recipe.id) : undefined}
+                        onRemoveImage={() => recipeImage.remove(recipe.id)}
                         isImageLoading={recipeImage.isLoading(recipe.id)}
                         imageError={recipeImage.getError(recipe.id)}
                         imageUrl={recipeImage.getImageUrl(recipe.id)}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2 } from 'lucide-react';
+import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, ExternalLink, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, ImageIcon, Info } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { API_CONFIG, STORAGE_KEYS } from '../constants';
 import { ApiKeySecurityDialog } from './ApiKeySecurityDialog';
@@ -27,7 +27,7 @@ export const Header: React.FC<HeaderProps> = ({
     onClearNotification,
     syncStatus,
 }) => {
-    const { useCopyPaste, setUseCopyPaste, apiKey, setApiKey, language, setLanguage, t } = useSettings();
+    const { useCopyPaste, setUseCopyPaste, apiKey, setApiKey, language, setLanguage, imageGenEnabled, setImageGenEnabled, t } = useSettings();
 
     // Check on mount if existing user needs to see the security warning
     const [showSecurityDialog, setShowSecurityDialog] = useState(() => {
@@ -303,6 +303,32 @@ export const Header: React.FC<HeaderProps> = ({
                                     >
                                         <ExternalLink size={14} />
                                     </a>
+                                </div>
+                            )}
+
+                            {!useCopyPaste && apiKey && (
+                                <div className="flex items-center gap-2 animate-in fade-in slide-in-from-top-2 duration-300">
+                                    <ImageIcon size={14} className="text-text-muted" aria-hidden="true" />
+                                    <span className={`text-sm transition-colors ${imageGenEnabled ? 'text-text-main font-medium' : 'text-text-muted'}`}>
+                                        {t.imageGen.label}
+                                    </span>
+                                    <button
+                                        onClick={() => setImageGenEnabled(!imageGenEnabled)}
+                                        className="relative w-12 h-6 bg-white/50 dark:bg-black/30 rounded-full border border-[var(--glass-border)] transition-colors hover:bg-white/70 dark:hover:bg-black/40"
+                                        role="switch"
+                                        aria-checked={imageGenEnabled}
+                                        aria-label={t.imageGen.label}
+                                    >
+                                        <span
+                                            className={`absolute top-0.5 w-5 h-5 bg-primary rounded-full shadow-md transition-all duration-200 ${imageGenEnabled ? 'left-6' : 'left-0.5'}`}
+                                        />
+                                    </button>
+                                    <TooltipButton
+                                        icon={<Info size={14} className="text-text-muted" />}
+                                        tooltip={t.imageGen.tooltip}
+                                        ariaLabel={t.imageGen.tooltip}
+                                        className="!p-1"
+                                    />
                                 </div>
                             )}
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -35,6 +35,7 @@ export const STORAGE_KEYS = {
     GIST_TOKEN_WARNING_SEEN: 'gist_token_warning_seen',
     STORAGE_TIPS_CACHE: 'storage_tips_cache',
     PHOTO_PRIVACY_ACK: 'photo_privacy_ack',
+    IMAGE_GEN_ENABLED: 'image_gen_enabled',
 } as const;
 
 /**

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -38,7 +38,8 @@ export const translations = {
             unexpectedError: "An unexpected error occurred. Please try again.",
             imageBlocked: "Image generation was blocked by the safety filter.",
             imageNoData: "The image model returned no image. Please try again.",
-            imageQuotaExceeded: "Image generation requires a paid Gemini API tier — the image model is not available on the free tier.",
+            imageQuotaExceeded: "Image generation quota exceeded. Please try again later.",
+            imageFreeTierUnsupported: "Image generation isn't available on the free Gemini tier. The toggle has been turned off.",
         },
         identifyIngredient: {
             buttonAriaLabel: "Identify ingredient from photo",
@@ -109,6 +110,10 @@ export const translations = {
             generating: "Generating image…",
             retry: "Retry",
             remove: "Remove image",
+        },
+        imageGen: {
+            label: "Image generation",
+            tooltip: "Show per-recipe image generation buttons. Requires a paid Gemini API tier; each image incurs a per-call charge on your account.",
         },
         emptyPantry: "Empty Pantry",
         clearShoppingList: "Clear Shopping List",
@@ -286,7 +291,8 @@ export const translations = {
             unexpectedError: "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut.",
             imageBlocked: "Die Bildgenerierung wurde vom Sicherheitsfilter blockiert.",
             imageNoData: "Das Bildmodell hat kein Bild zurückgegeben. Bitte versuche es erneut.",
-            imageQuotaExceeded: "Die Bildgenerierung erfordert ein kostenpflichtiges Gemini-API-Kontingent — im kostenlosen Tier ist das Bildmodell nicht verfügbar.",
+            imageQuotaExceeded: "Bildgenerierungs-Kontingent erschöpft. Bitte später erneut versuchen.",
+            imageFreeTierUnsupported: "Bildgenerierung ist im kostenlosen Gemini-Tier nicht verfügbar. Der Schalter wurde ausgeschaltet.",
         },
         identifyIngredient: {
             buttonAriaLabel: "Zutat per Foto erkennen",
@@ -357,6 +363,10 @@ export const translations = {
             generating: "Bild wird generiert…",
             retry: "Erneut versuchen",
             remove: "Bild entfernen",
+        },
+        imageGen: {
+            label: "Bildgenerierung",
+            tooltip: "Zeigt pro Rezept eine Schaltfläche zur Bildgenerierung an. Erfordert ein kostenpflichtiges Gemini-API-Kontingent; jedes Bild verursacht Kosten auf deinem Konto.",
         },
         emptyPantry: "Vorrat leeren",
         clearShoppingList: "Einkaufsliste leeren",
@@ -534,7 +544,8 @@ export const translations = {
             unexpectedError: "Une erreur inattendue s'est produite. Veuillez réessayer.",
             imageBlocked: "La génération d'image a été bloquée par le filtre de sécurité.",
             imageNoData: "Le modèle d'image n'a renvoyé aucune image. Veuillez réessayer.",
-            imageQuotaExceeded: "La génération d'images nécessite un palier Gemini payant — le modèle d'image n'est pas disponible dans le palier gratuit.",
+            imageQuotaExceeded: "Quota de génération d'images dépassé. Veuillez réessayer plus tard.",
+            imageFreeTierUnsupported: "La génération d'images n'est pas disponible dans le palier gratuit Gemini. L'interrupteur a été désactivé.",
         },
         identifyIngredient: {
             buttonAriaLabel: "Identifier l'ingrédient à partir d'une photo",
@@ -605,6 +616,10 @@ export const translations = {
             generating: "Génération de l'image…",
             retry: "Réessayer",
             remove: "Supprimer l'image",
+        },
+        imageGen: {
+            label: "Génération d'images",
+            tooltip: "Affiche les boutons de génération d'image pour chaque recette. Nécessite un palier Gemini payant ; chaque image entraîne des frais facturés à votre compte.",
         },
         emptyPantry: "Vider le garde-manger",
         clearShoppingList: "Vider la liste de courses",
@@ -782,7 +797,8 @@ export const translations = {
             unexpectedError: "Ocurrió un error inesperado. Por favor, inténtalo de nuevo.",
             imageBlocked: "La generación de imágenes fue bloqueada por el filtro de seguridad.",
             imageNoData: "El modelo de imagen no devolvió ninguna imagen. Por favor, inténtalo de nuevo.",
-            imageQuotaExceeded: "La generación de imágenes requiere un plan Gemini de pago — el modelo de imagen no está disponible en el plan gratuito.",
+            imageQuotaExceeded: "Cuota de generación de imágenes agotada. Por favor, inténtalo más tarde.",
+            imageFreeTierUnsupported: "La generación de imágenes no está disponible en el plan gratuito de Gemini. El interruptor se ha desactivado.",
         },
         identifyIngredient: {
             buttonAriaLabel: "Identificar ingrediente desde una foto",
@@ -853,6 +869,10 @@ export const translations = {
             generating: "Generando imagen…",
             retry: "Reintentar",
             remove: "Eliminar imagen",
+        },
+        imageGen: {
+            label: "Generación de imágenes",
+            tooltip: "Muestra botones de generación de imágenes por receta. Requiere un plan Gemini de pago; cada imagen genera un cargo en tu cuenta.",
         },
         emptyPantry: "Vaciar despensa",
         clearShoppingList: "Vaciar lista de compras",

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, type ReactNode } from 'react';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { translations } from '../constants/translations';
 import { STORAGE_KEYS, DEFAULTS } from '../constants';
@@ -71,6 +71,8 @@ interface SettingsContextType {
     setStyleWishes: (wishes: string[]) => void;
     language: string;
     setLanguage: (lang: string) => void;
+    imageGenEnabled: boolean;
+    setImageGenEnabled: (enabled: boolean) => void;
     t: TranslationType;
     storagePersistError: boolean;
 }
@@ -123,14 +125,25 @@ const getInitialStyleWishes = (): string[] => {
 
 export const SettingsProvider = ({ children }: { children: ReactNode }) => {
     const [useCopyPaste, setUseCopyPaste, useCopyPasteError] = useLocalStorage<boolean>(STORAGE_KEYS.USE_COPY_PASTE, getInitialUseCopyPaste());
-    const [apiKey, setApiKey, apiKeyError] = useLocalStorage<string>(STORAGE_KEYS.API_KEY, '');
+    const [apiKey, setApiKeyRaw, apiKeyError] = useLocalStorage<string>(STORAGE_KEYS.API_KEY, '');
     const [people, setPeople, peopleError] = useLocalStorage<number>(STORAGE_KEYS.PEOPLE_COUNT, DEFAULTS.PEOPLE_COUNT);
     const [meals, setMeals, mealsError] = useLocalStorage<number>(STORAGE_KEYS.MEALS_COUNT, DEFAULTS.MEALS_COUNT);
     const [diet, setDiet, dietError] = useLocalStorage<string>(STORAGE_KEYS.DIET_PREFERENCE, DEFAULTS.DIET);
     const [styleWishes, setStyleWishes, styleWishesError] = useLocalStorage<string[]>(STORAGE_KEYS.STYLE_WISHES, getInitialStyleWishes());
     const [language, setLanguage, languageError] = useLocalStorage<string>(STORAGE_KEYS.LANGUAGE, getInitialLanguage());
+    const [imageGenEnabled, setImageGenEnabled, imageGenEnabledError] = useLocalStorage<boolean>(STORAGE_KEYS.IMAGE_GEN_ENABLED, false);
 
-    const storagePersistError = useCopyPasteError || apiKeyError || peopleError || mealsError || dietError || styleWishesError || languageError;
+    // Reset the image-generation opt-in whenever the API key changes. The
+    // toggle is an explicit acknowledgement that the key supports paid
+    // image-gen, so a new key — possibly free-tier — must be re-confirmed.
+    // Skip the reset when the new value equals the current one (the input
+    // fires onChange per keystroke; identical values shouldn't reset).
+    const setApiKey = useCallback((key: string) => {
+        if (key !== apiKey && imageGenEnabled) setImageGenEnabled(false);
+        setApiKeyRaw(key);
+    }, [apiKey, setApiKeyRaw, imageGenEnabled, setImageGenEnabled]);
+
+    const storagePersistError = useCopyPasteError || apiKeyError || peopleError || mealsError || dietError || styleWishesError || languageError || imageGenEnabledError;
 
     const t = getTranslations(language);
 
@@ -142,6 +155,7 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
         diet, setDiet,
         styleWishes, setStyleWishes,
         language, setLanguage,
+        imageGenEnabled, setImageGenEnabled,
         t,
         storagePersistError
     };

--- a/src/hooks/useRecipeImage.ts
+++ b/src/hooks/useRecipeImage.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSettings } from '../contexts/SettingsContext';
-import { generateRecipeImage } from '../services/llm';
+import { generateRecipeImage, ImageGenError } from '../services/llm';
 import {
     deleteRecipeImage,
     getAllRecipeImageIds,
@@ -24,8 +24,25 @@ import type { Recipe } from '../types';
  * intentionally device-local: they are not part of the Gist sync payload
  * (cheap to regenerate, expensive to ship) and not part of share URLs.
  */
-export function useRecipeImage(recipeIds: readonly string[]) {
+interface UseRecipeImageOptions {
+    /**
+     * Called once when a `generate()` attempt structurally identifies the
+     * current API key as free-tier (image-gen quota is 0). Wired by App.tsx
+     * to flip the user-facing image-generation toggle off and surface a
+     * toast. Distinct from the generic per-recipe error path so the caller
+     * can take a UI-wide action rather than just showing a card-level error.
+     */
+    onFreeTierLimit?: () => void;
+}
+
+export function useRecipeImage(recipeIds: readonly string[], options: UseRecipeImageOptions = {}) {
     const { apiKey, t } = useSettings();
+    // Keep the callback in a ref so `generate` stays referentially stable
+    // even if the parent passes a fresh function each render.
+    const onFreeTierLimitRef = useRef(options.onFreeTierLimit);
+    useEffect(() => {
+        onFreeTierLimitRef.current = options.onFreeTierLimit;
+    }, [options.onFreeTierLimit]);
     const [imageUrls, setImageUrls] = useState<Record<string, string>>({});
     const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
     const [errors, setErrors] = useState<Record<string, string>>({});
@@ -196,8 +213,16 @@ export function useRecipeImage(recipeIds: readonly string[]) {
             await setRecipeImage(recipe.id, blob);
             replaceUrl(recipe.id, blob);
         } catch (err) {
-            const message = err instanceof Error ? err.message : t.errors.unexpectedError;
-            setErrors(prev => ({ ...prev, [recipe.id]: message }));
+            // Free-tier zero-limit is a UI-wide signal (snap the toggle off),
+            // not a per-card error — the card-level button is about to
+            // disappear anyway, so suppressing the per-recipe error here
+            // avoids a stale message lingering in state.
+            if (err instanceof ImageGenError && err.kind === 'free-tier-zero-limit') {
+                onFreeTierLimitRef.current?.();
+            } else {
+                const message = err instanceof Error ? err.message : t.errors.unexpectedError;
+                setErrors(prev => ({ ...prev, [recipe.id]: message }));
+            }
         } finally {
             inFlightRef.current.delete(recipe.id);
             setLoadingIds(prev => {

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -84,6 +84,24 @@ export interface ErrorTranslations {
   imageBlocked: string;
   imageNoData: string;
   imageQuotaExceeded: string;
+  imageFreeTierUnsupported: string;
+}
+
+/**
+ * Error thrown by `generateRecipeImage` when the failure is structurally
+ * identifiable (vs. a generic message). Lets callers react programmatically —
+ * e.g. snap an "image generation enabled" toggle off on a free-tier hit
+ * without parsing translated strings.
+ */
+export type ImageGenErrorKind = 'free-tier-zero-limit';
+
+export class ImageGenError extends Error {
+  readonly kind: ImageGenErrorKind;
+  constructor(message: string, kind: ImageGenErrorKind) {
+    super(message);
+    this.name = 'ImageGenError';
+    this.kind = kind;
+  }
 }
 
 
@@ -378,6 +396,43 @@ export const fetchStorageTip = async (
 };
 
 /**
+ * Detects the free-tier "limit: 0" RESOURCE_EXHAUSTED response shape. Reads
+ * both the structured `QuotaFailure` details and the human-readable message,
+ * since the structured payload is the documented contract but the message has
+ * historically been the only reliable carrier.
+ */
+const isFreeTierZeroLimit = (errorData: unknown): boolean => {
+  if (!errorData || typeof errorData !== 'object') return false;
+  const err = (errorData as { error?: unknown }).error;
+  if (!err || typeof err !== 'object') return false;
+
+  const message = (err as { message?: unknown }).message;
+  if (typeof message === 'string' && /free_tier_requests/i.test(message) && /limit:\s*0\b/.test(message)) {
+    return true;
+  }
+
+  const details = (err as { details?: unknown }).details;
+  if (Array.isArray(details)) {
+    for (const d of details) {
+      if (!d || typeof d !== 'object') continue;
+      const type = (d as { '@type'?: unknown })['@type'];
+      if (typeof type !== 'string' || !type.includes('QuotaFailure')) continue;
+      const violations = (d as { violations?: unknown }).violations;
+      if (!Array.isArray(violations)) continue;
+      for (const v of violations) {
+        if (!v || typeof v !== 'object') continue;
+        const metric = (v as { quotaMetric?: unknown }).quotaMetric;
+        const value = (v as { quotaValue?: unknown }).quotaValue;
+        if (typeof metric === 'string' && /free_tier/i.test(metric) && String(value) === '0') {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+};
+
+/**
  * Generates an appetizing food photo for a recipe via Gemini's image model.
  * Returns the image as a Blob so the caller can persist it in IndexedDB
  * without the ~33% size penalty of base64.
@@ -428,10 +483,16 @@ export const generateRecipeImage = async (
       // `response.json()` resolves (without throwing) and would otherwise
       // crash the `errorData.error` access below.
       const errorData = (await response.json().catch(() => ({}))) || {};
-      // Free-tier Gemini API has limit: 0 for image-generation models, so the
-      // very first request returns 429 RESOURCE_EXHAUSTED. The raw Google
-      // message is opaque to non-developers — surface an actionable hint.
-      if (response.status === 429 || errorData.error?.status === 'RESOURCE_EXHAUSTED') {
+      const isRateLimit = response.status === 429 || errorData.error?.status === 'RESOURCE_EXHAUSTED';
+      if (isRateLimit) {
+        // Free-tier keys have a structural limit of 0 for image-generation
+        // models — distinguishable from a paid-tier user who merely blew
+        // their per-minute/day cap. Surface it as a typed error so the
+        // caller can flip the user-facing toggle off instead of just
+        // displaying a generic rate-limit message.
+        if (isFreeTierZeroLimit(errorData)) {
+          throw new ImageGenError(errors.imageFreeTierUnsupported, 'free-tier-zero-limit');
+        }
         throw new Error(errors.imageQuotaExceeded);
       }
       throw new Error(errorData.error?.message || errors.unexpectedError);


### PR DESCRIPTION
## Summary
- Gate the per-recipe image-generation button behind an explicit opt-in toggle (header, API-key mode only), since `gemini-2.5-flash-image` is paid-tier-only via the API and free-tier keys fail with `free_tier_requests limit:0` on every call.
- Detect that failure mode structurally (`QuotaFailure` violation details + message regex) and snap the toggle off with a translated toast when it occurs; reset the toggle whenever the API key changes.
- Keep the per-image delete button available regardless of toggle/mode — removing existing images is a local IndexedDB operation that shouldn't require API access.

## Test plan
- [ ] Enter an API key → toggle appears in the header below the key input; defaults to off.
- [ ] Flip toggle on → per-recipe "Generate image" button appears.
- [ ] With a free-tier key, click generate → toggle flips off and `imageFreeTierUnsupported` toast appears.
- [ ] With a paid-tier key, click generate → image generates and persists.
- [ ] Change API key → toggle resets to off.
- [ ] Toggle off (or switch to copy-paste mode) with an existing image → delete button on the image is still available.
- [ ] Switch through all four languages → toggle label/tooltip and free-tier toast are translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)