### PR TITLE
feat(undo): anchor undo toasts to the action site

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,14 +178,11 @@ function App() {
     showNotification({ message, type: 'error' });
   }, [sync.status, sync.errorKind, showNotification, t.sync.errorUnauthorized, t.sync.errorNotFound, t.sync.errorPayload, t.sync.errorNetwork]);
 
-  // Cleanup timeouts on unmount
+  // Cleanup notification timeout on unmount
   useEffect(() => {
     return () => {
       if (notificationTimeoutRef.current) {
         clearTimeout(notificationTimeoutRef.current);
-      }
-      if (pendingDeleteTimeoutRef.current) {
-        clearTimeout(pendingDeleteTimeoutRef.current);
       }
     };
   }, []);
@@ -374,11 +371,13 @@ function App() {
   }, [setMealPlan]);
 
   const deleteRecipe = useCallback((recipeId: string) => {
-    if (!mealPlan) return;
-    // Flush a still-pending earlier deletion so it doesn't get lost.
-    if (pendingDeleteTimeoutRef.current && pendingDeleteRecipeId && pendingDeleteRecipeId !== recipeId) {
+    // Clear any pending delete-timer. If a different recipe was pending, flush
+    // it synchronously so it doesn't get stranded.
+    if (pendingDeleteTimeoutRef.current) {
       clearTimeout(pendingDeleteTimeoutRef.current);
-      commitRecipeDeletion(pendingDeleteRecipeId);
+      if (pendingDeleteRecipeId && pendingDeleteRecipeId !== recipeId) {
+        commitRecipeDeletion(pendingDeleteRecipeId);
+      }
     }
     setPendingDeleteRecipeId(recipeId);
     pendingDeleteTimeoutRef.current = setTimeout(() => {
@@ -405,7 +404,7 @@ function App() {
       },
       timeout: 5000
     });
-  }, [mealPlan, pendingDeleteRecipeId, commitRecipeDeletion, showNotification, clearNotification, t.undo.recipeDeleted, t.undo.action]);
+  }, [pendingDeleteRecipeId, commitRecipeDeletion, showNotification, clearNotification, t.undo.recipeDeleted, t.undo.action]);
 
   // After a new plan replaces an existing one, offer a one-tap undo.
   // Restores the prior plan and the shopping-list checkmarks that were cleared.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,11 +178,14 @@ function App() {
     showNotification({ message, type: 'error' });
   }, [sync.status, sync.errorKind, showNotification, t.sync.errorUnauthorized, t.sync.errorNotFound, t.sync.errorPayload, t.sync.errorNetwork]);
 
-  // Cleanup timeout on unmount
+  // Cleanup timeouts on unmount
   useEffect(() => {
     return () => {
       if (notificationTimeoutRef.current) {
         clearTimeout(notificationTimeoutRef.current);
+      }
+      if (pendingDeleteTimeoutRef.current) {
+        clearTimeout(pendingDeleteTimeoutRef.current);
       }
     };
   }, []);
@@ -295,6 +298,7 @@ function App() {
     showNotification({
       message: t.undo.shoppingListCleared,
       type: 'undo',
+      anchor: 'shopping-list',
       action: {
         label: t.undo.action,
         ariaLabel: `${t.undo.action} ${t.undo.shoppingListCleared.toLowerCase()}`,
@@ -320,6 +324,7 @@ function App() {
     showNotification({
       message: t.undo.pantryEmptied,
       type: 'undo',
+      anchor: 'pantry',
       action: {
         label: t.undo.action,
         ariaLabel: `${t.undo.action} ${t.undo.pantryEmptied.toLowerCase()}`,
@@ -354,29 +359,53 @@ function App() {
     setAppliances(prev => prev.filter(a => a !== applianceToRemove));
   }, [setAppliances]);
 
+  // Recipe deletion is deferred so the toast can occupy the card's grid slot
+  // for 5s. If the user deletes a second recipe before the timer fires, we
+  // commit the previous deletion synchronously to avoid stranding it.
+  const [pendingDeleteRecipeId, setPendingDeleteRecipeId] = useState<string | null>(null);
+  const pendingDeleteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const commitRecipeDeletion = useCallback((recipeId: string) => {
+    setMealPlan(prev => {
+      if (!prev) return prev;
+      const remaining = prev.recipes.filter(r => r.id !== recipeId);
+      return remaining.length === 0 ? null : { ...prev, recipes: remaining };
+    });
+  }, [setMealPlan]);
+
   const deleteRecipe = useCallback((recipeId: string) => {
     if (!mealPlan) return;
-    const backup = mealPlan;
-    const updatedRecipes = mealPlan.recipes.filter(r => r.id !== recipeId);
-    if (updatedRecipes.length === 0) {
-      setMealPlan(null);
-    } else {
-      setMealPlan({ ...mealPlan, recipes: updatedRecipes });
+    // Flush a still-pending earlier deletion so it doesn't get lost.
+    if (pendingDeleteTimeoutRef.current && pendingDeleteRecipeId && pendingDeleteRecipeId !== recipeId) {
+      clearTimeout(pendingDeleteTimeoutRef.current);
+      commitRecipeDeletion(pendingDeleteRecipeId);
     }
+    setPendingDeleteRecipeId(recipeId);
+    pendingDeleteTimeoutRef.current = setTimeout(() => {
+      commitRecipeDeletion(recipeId);
+      setPendingDeleteRecipeId(null);
+      pendingDeleteTimeoutRef.current = null;
+    }, 5000);
     showNotification({
       message: t.undo.recipeDeleted,
       type: 'undo',
+      anchor: 'recipe',
+      anchorId: recipeId,
       action: {
         label: t.undo.action,
         ariaLabel: `${t.undo.action} ${t.undo.recipeDeleted.toLowerCase()}`,
         onClick: () => {
-          setMealPlan(backup);
+          if (pendingDeleteTimeoutRef.current) {
+            clearTimeout(pendingDeleteTimeoutRef.current);
+            pendingDeleteTimeoutRef.current = null;
+          }
+          setPendingDeleteRecipeId(null);
           clearNotification();
         }
       },
       timeout: 5000
     });
-  }, [mealPlan, setMealPlan, showNotification, clearNotification, t.undo.recipeDeleted, t.undo.action]);
+  }, [mealPlan, pendingDeleteRecipeId, commitRecipeDeletion, showNotification, clearNotification, t.undo.recipeDeleted, t.undo.action]);
 
   // After a new plan replaces an existing one, offer a one-tap undo.
   // Restores the prior plan and the shopping-list checkmarks that were cleared.
@@ -553,6 +582,7 @@ function App() {
         onShowNotification={showNotification}
         onClearNotification={clearNotification}
         syncStatus={sync.status}
+        notification={notification}
       />
 
       <main className="app-container flex flex-col gap-8">
@@ -578,6 +608,7 @@ function App() {
               onEmptyPantry={emptyPantry}
               isMinimized={pantryMinimized}
               onToggleMinimize={handleTogglePantryMinimize}
+              notification={notification}
             />
 
             <SpiceRack
@@ -613,6 +644,7 @@ function App() {
                   onViewSingle={() => openShoppingListView(mealPlan.shoppingList)}
                   onClear={clearShoppingList}
                   onPersistErrorChange={setShoppingListCheckedPersistError}
+                  notification={notification}
                 />
 
                 <div>
@@ -643,6 +675,8 @@ function App() {
                         onGenerateImage={canGenerateImages ? () => recipeImage.generate(recipe) : undefined}
                         onRemoveImage={() => recipeImage.remove(recipe.id)}
                         isImageLoading={recipeImage.isLoading(recipe.id)}
+                        pendingDelete={pendingDeleteRecipeId === recipe.id}
+                        deleteNotification={pendingDeleteRecipeId === recipe.id ? notification : null}
                         imageError={recipeImage.getError(recipe.id)}
                         imageUrl={recipeImage.getImageUrl(recipe.id)}
                       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -675,7 +675,13 @@ function App() {
                         onRemoveImage={() => recipeImage.remove(recipe.id)}
                         isImageLoading={recipeImage.isLoading(recipe.id)}
                         pendingDelete={pendingDeleteRecipeId === recipe.id}
-                        deleteNotification={pendingDeleteRecipeId === recipe.id ? notification : null}
+                        deleteNotification={
+                          pendingDeleteRecipeId === recipe.id &&
+                          notification?.anchor === 'recipe' &&
+                          notification?.anchorId === recipe.id
+                            ? notification
+                            : null
+                        }
                         imageError={recipeImage.getError(recipe.id)}
                         imageUrl={recipeImage.getImageUrl(recipe.id)}
                       />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { ApiKeySecurityDialog } from './ApiKeySecurityDialog';
 import { ClearApiKeyDialog } from './ClearApiKeyDialog';
 import { GistSyncDialog } from './GistSyncDialog';
 import { TooltipButton } from './ui/TooltipButton';
+import { UndoToast } from './ui/UndoToast';
 import { buildExportData, downloadExportFile, readImportFile, applyImportData } from '../utils/dataTransfer';
 import type { Notification } from '../types';
 import type { SyncStatus } from '../hooks/useGistSync';
@@ -17,6 +18,7 @@ interface HeaderProps {
     onShowNotification: (notification: Notification) => void;
     onClearNotification: () => void;
     syncStatus: SyncStatus;
+    notification: Notification | null;
 }
 
 export const Header: React.FC<HeaderProps> = ({
@@ -26,6 +28,7 @@ export const Header: React.FC<HeaderProps> = ({
     onShowNotification,
     onClearNotification,
     syncStatus,
+    notification,
 }) => {
     const { useCopyPaste, setUseCopyPaste, apiKey, setApiKey, language, setLanguage, imageGenEnabled, setImageGenEnabled, t } = useSettings();
 
@@ -113,6 +116,7 @@ export const Header: React.FC<HeaderProps> = ({
         onShowNotification({
             message: t.undo.apiKeyCleared,
             type: 'undo',
+            anchor: 'api-key',
             action: {
                 label: t.undo.action,
                 ariaLabel: `${t.undo.action} ${t.undo.apiKeyCleared.toLowerCase()}`,
@@ -383,6 +387,12 @@ export const Header: React.FC<HeaderProps> = ({
                                 />
                             </div>
                         </>
+                    )}
+
+                    {/* Anchored undo toast — renders in both minimized and expanded
+                        states since clearApiKeyWithUndo can fire from either. */}
+                    {notification?.anchor === 'api-key' && (
+                        <UndoToast notification={notification} />
                     )}
                 </div>
             </div>

--- a/src/components/PantryInput.tsx
+++ b/src/components/PantryInput.tsx
@@ -1,11 +1,11 @@
 import React, { useState, forwardRef, useImperativeHandle, useRef, useEffect } from 'react';
 import { Plus, Trash2, Refrigerator, Info, Loader2, X, Camera } from 'lucide-react';
-import type { PantryItem } from '../types';
+import type { PantryItem, Notification } from '../types';
 import { generateId } from '../utils/idGenerator';
 import { useSettings } from '../contexts/SettingsContext';
 import { useStorageTips } from '../hooks/useStorageTips';
 import { useLocalStorage } from '../hooks/useLocalStorage';
-import { PanelHeader } from './ui';
+import { PanelHeader, UndoToast } from './ui';
 import { PhotoPrivacyDialog } from './PhotoPrivacyDialog';
 import { STORAGE_KEYS, VALIDATION } from '../constants';
 import { downscaleImage } from '../utils/imageDownscale';
@@ -19,6 +19,7 @@ interface PantryInputProps {
     onEmptyPantry: () => void;
     isMinimized: boolean;
     onToggleMinimize: () => void;
+    notification?: Notification | null;
 }
 
 export interface PantryInputRef {
@@ -32,7 +33,8 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
     onUpdatePantryItem,
     onEmptyPantry,
     isMinimized,
-    onToggleMinimize
+    onToggleMinimize,
+    notification
 }, ref) => {
     const { t, useCopyPaste, apiKey, language } = useSettings();
     const tipsActive = !useCopyPaste && !!apiKey;
@@ -329,9 +331,13 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
 
                     <div className="grid grid-cols-1 gap-2 mt-2">
                         {pantryItems.length === 0 && (
-                            <div className="text-text-muted text-center py-8 italic border border-dashed border-[var(--glass-border)] rounded-xl bg-white/10">
-                                {t.noVeg}
-                            </div>
+                            notification?.anchor === 'pantry' ? (
+                                <UndoToast notification={notification} />
+                            ) : (
+                                <div className="text-text-muted text-center py-8 italic border border-dashed border-[var(--glass-border)] rounded-xl bg-white/10">
+                                    {t.noVeg}
+                                </div>
+                            )
                         )}
                         {pantryItems.map((item) => {
                             const cachedTip = tipsActive ? getTip(item.name) : undefined;

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import { Clock, ChefHat, AlertCircle, ExternalLink, Sun, SunDim, Trash2, ListChecks, X, Lightbulb, ChevronUp, ChevronDown, Image as ImageIcon, Loader2, RefreshCw } from 'lucide-react';
 import { motion } from 'framer-motion';
-import type { Recipe } from '../types';
+import type { Recipe, Notification } from '../types';
 import { useSettings } from '../contexts/SettingsContext';
+import { UndoToast } from './ui/UndoToast';
 
 interface RecipeCardProps {
     recipe: Recipe;
@@ -33,9 +34,15 @@ interface RecipeCardProps {
      * IndexedDB). Undefined when no image has been generated yet.
      */
     imageUrl?: string;
+    /**
+     * When true, the card renders only an undo toast in place of its content
+     * so the slot stays in the grid during the 5s undo window.
+     */
+    pendingDelete?: boolean;
+    deleteNotification?: Notification | null;
 }
 
-export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenInNewTab = false, isStandalone = false, wakeLock, onDelete, onViewSingle, onClose, missingIngredientsMinimized = false, onToggleMissingIngredientsMinimize, onGenerateImage, onRemoveImage, isImageLoading = false, imageError, imageUrl }) => {
+export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenInNewTab = false, isStandalone = false, wakeLock, onDelete, onViewSingle, onClose, missingIngredientsMinimized = false, onToggleMissingIngredientsMinimize, onGenerateImage, onRemoveImage, isImageLoading = false, imageError, imageUrl, pendingDelete = false, deleteNotification }) => {
     const { t } = useSettings();
     const [struckIngredients, setStruckIngredients] = useState<Set<number>>(new Set());
     const [activeStep, setActiveStep] = useState<number | null>(null);
@@ -97,6 +104,18 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
         }
     }, [recipe]);
 
+
+    if (pendingDelete && deleteNotification) {
+        return (
+            <motion.div
+                initial={{ opacity: 1, y: 0 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="glass-card p-8 flex flex-col h-full relative shadow-glass"
+            >
+                <UndoToast notification={deleteNotification} />
+            </motion.div>
+        );
+    }
 
     return (
         <motion.div

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -105,14 +105,17 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
     }, [recipe]);
 
 
-    if (pendingDelete && deleteNotification) {
+    // Hold the slot for the full 5s deletion window even if the toast is
+    // displaced by another notification — otherwise the card would flash back
+    // into view before the timer fires.
+    if (pendingDelete) {
         return (
             <motion.div
                 initial={{ opacity: 1, y: 0 }}
                 animate={{ opacity: 1, y: 0 }}
                 className="glass-card p-8 flex flex-col h-full relative shadow-glass"
             >
-                <UndoToast notification={deleteNotification} />
+                {deleteNotification && <UndoToast notification={deleteNotification} />}
             </motion.div>
         );
     }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -3,6 +3,7 @@ import { Utensils, ChefHat, Users, Salad, Sparkles, ChevronUp, ChevronDown, Plus
 import { useSettings } from '../contexts/SettingsContext';
 import type { Notification } from '../types';
 import { VALIDATION } from '../constants';
+import { UndoToast } from './ui/UndoToast';
 
 export interface SettingsPanelRef {
     flushPendingInput: () => string | null;
@@ -51,30 +52,6 @@ export const SettingsPanel = forwardRef<SettingsPanelRef, SettingsPanelProps>(({
 
     const handleRemoveStyleWish = (wishToRemove: string) => {
         setStyleWishes(styleWishes.filter(wish => wish !== wishToRemove));
-    };
-
-    // Helper function to render text with clickable URLs
-    const renderTextWithLinks = (text: string) => {
-        const urlRegex = /(https?:\/\/[^\s]+)/g;
-        const isUrl = (part: string) => /^https?:\/\/[^\s]+$/.test(part);
-        const parts = text.split(urlRegex);
-
-        return parts.map((part, index) => {
-            if (isUrl(part)) {
-                return (
-                    <a
-                        key={index}
-                        href={part}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="underline hover:text-red-800 transition-colors"
-                    >
-                        {part}
-                    </a>
-                );
-            }
-            return <span key={index}>{part}</span>;
-        });
     };
 
     return (
@@ -249,32 +226,8 @@ export const SettingsPanel = forwardRef<SettingsPanelRef, SettingsPanelProps>(({
                 )}
             </button>
 
-            {notification && (
-                <div
-                    role="alert"
-                    aria-live="assertive"
-                    aria-atomic="true"
-                    className={`p-4 rounded-xl border text-sm animate-in fade-in slide-in-from-top-2 flex items-center justify-between gap-3 ${
-                        notification.type === 'error'
-                            ? 'bg-red-50 text-red-600 border-red-100 dark:bg-red-950/50 dark:text-red-400 dark:border-red-900'
-                            : 'bg-amber-50 text-amber-800 border-amber-200 dark:bg-amber-950/50 dark:text-amber-300 dark:border-amber-800'
-                    }`}
-                >
-                    <span className="flex-1">{renderTextWithLinks(notification.message)}</span>
-                    {notification.action && (
-                        <button
-                            onClick={notification.action.onClick}
-                            aria-label={notification.action.ariaLabel || notification.action.label}
-                            className={`px-3 py-1 rounded-lg font-medium text-sm transition-colors shrink-0 ${
-                                notification.type === 'error'
-                                    ? 'bg-red-100 hover:bg-red-200 dark:bg-red-900 dark:hover:bg-red-800'
-                                    : 'bg-amber-200 hover:bg-amber-300 dark:bg-amber-800 dark:hover:bg-amber-700'
-                            }`}
-                        >
-                            {notification.action.label}
-                        </button>
-                    )}
-                </div>
+            {notification && (notification.anchor === undefined || notification.anchor === 'generate') && (
+                <UndoToast notification={notification} />
             )}
         </>
     );

--- a/src/components/ShoppingList.tsx
+++ b/src/components/ShoppingList.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useCallback, useState, useEffect } from 'react';
 import { ShoppingCart, ExternalLink, ChevronUp, ChevronDown, Info, X, Trash2 } from 'lucide-react';
 import { motion } from 'framer-motion';
-import type { Ingredient, MealPlan } from '../types';
+import type { Ingredient, MealPlan, Notification } from '../types';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { useSettings } from '../contexts/SettingsContext';
 import { STORAGE_KEYS } from '../constants';
 import { getItemKey, listsMatch } from '../utils/shoppingListHelpers';
+import { UndoToast } from './ui/UndoToast';
 
 interface ShoppingListProps {
     items: Ingredient[];
@@ -16,9 +17,10 @@ interface ShoppingListProps {
     onClose?: () => void;
     onClear?: () => void;
     onPersistErrorChange?: (hasError: boolean) => void;
+    notification?: Notification | null;
 }
 
-export const ShoppingList: React.FC<ShoppingListProps> = ({ items, isMinimized = false, onToggleMinimize, isStandaloneView = false, onViewSingle, onClose, onClear, onPersistErrorChange }) => {
+export const ShoppingList: React.FC<ShoppingListProps> = ({ items, isMinimized = false, onToggleMinimize, isStandaloneView = false, onViewSingle, onClose, onClear, onPersistErrorChange, notification }) => {
     const { t } = useSettings();
 
     // Load checked items from localStorage (used for main view and own list in standalone)
@@ -132,7 +134,22 @@ export const ShoppingList: React.FC<ShoppingListProps> = ({ items, isMinimized =
     }, [isStandaloneView, isOwnList, setLocalStorageChecked]);
 
 
-    if (items.length === 0) return null;
+    if (items.length === 0) {
+        if (notification?.anchor === 'shopping-list') {
+            // Toast occupies the shopping-list slot while the undo window is open.
+            return (
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0 }}
+                    className="glass-panel p-6"
+                >
+                    <UndoToast notification={notification} />
+                </motion.div>
+            );
+        }
+        return null;
+    }
 
     return (
         <motion.div

--- a/src/components/ui/UndoToast.tsx
+++ b/src/components/ui/UndoToast.tsx
@@ -1,0 +1,54 @@
+import type { Notification } from '../../types';
+
+interface UndoToastProps {
+    notification: Notification;
+}
+
+const renderTextWithLinks = (text: string) => {
+    const urlRegex = /(https?:\/\/[^\s]+)/g;
+    const isUrl = (part: string) => /^https?:\/\/[^\s]+$/.test(part);
+    return text.split(urlRegex).map((part, index) => {
+        if (isUrl(part)) {
+            return (
+                <a
+                    key={index}
+                    href={part}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-red-800 transition-colors"
+                >
+                    {part}
+                </a>
+            );
+        }
+        return <span key={index}>{part}</span>;
+    });
+};
+
+export const UndoToast = ({ notification }: UndoToastProps) => (
+    <div
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+        className={`p-4 rounded-xl border text-sm animate-in fade-in slide-in-from-top-2 flex items-center justify-between gap-3 ${
+            notification.type === 'error'
+                ? 'bg-red-50 text-red-600 border-red-100 dark:bg-red-950/50 dark:text-red-400 dark:border-red-900'
+                : 'bg-amber-50 text-amber-800 border-amber-200 dark:bg-amber-950/50 dark:text-amber-300 dark:border-amber-800'
+        }`}
+    >
+        <span className="flex-1">{renderTextWithLinks(notification.message)}</span>
+        {notification.action && (
+            <button
+                onClick={notification.action.onClick}
+                aria-label={notification.action.ariaLabel || notification.action.label}
+                className={`px-3 py-1 rounded-lg font-medium text-sm transition-colors shrink-0 ${
+                    notification.type === 'error'
+                        ? 'bg-red-100 hover:bg-red-200 dark:bg-red-900 dark:hover:bg-red-800'
+                        : 'bg-amber-200 hover:bg-amber-300 dark:bg-amber-800 dark:hover:bg-amber-700'
+                }`}
+            >
+                {notification.action.label}
+            </button>
+        )}
+    </div>
+);

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,2 +1,3 @@
 export { TooltipButton } from './TooltipButton';
 export { PanelHeader } from './PanelHeader';
+export { UndoToast } from './UndoToast';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,10 +56,18 @@ export interface MealPlan {
 
 /**
  * A notification displayed to the user (error or undo message).
+ *
+ * `anchor` controls where the toast renders. Omitted (or `'generate'`) keeps
+ * it below the Generate button — the legacy spot. Other anchors render the
+ * toast where the destructive action happened so it stays in viewport on
+ * narrow screens. `anchorId` disambiguates among multiple instances of the
+ * same anchor (currently only used for `'recipe'` to identify which card).
  */
 export interface Notification {
   message: string;
   type: 'error' | 'undo';
+  anchor?: 'generate' | 'shopping-list' | 'pantry' | 'recipe' | 'api-key';
+  anchorId?: string;
   action?: {
     label: string;
     onClick: () => void;


### PR DESCRIPTION
## Summary
- Undo toasts now render where the destructive action happened instead of always under the Generate button (which is off-screen on narrow viewports and below the fold for multi-recipe plans).
- Adds an `anchor` discriminator to `Notification` (`'generate' | 'shopping-list' | 'pantry' | 'recipe' | 'api-key'`); unset/`'generate'` keeps the legacy spot, so every error notification and the meal-plan-replaced undo are unchanged.
- Extracts the toast UI into `src/components/ui/UndoToast.tsx` and renders it at the matching anchor in `Header`, `PantryInput`, `ShoppingList`, and `RecipeCard`.
- Recipe deletion is deferred 5s so the toast can occupy the card's grid slot without reflow; deleting a second recipe during the window commits the first to avoid stranding it.

## Test plan
- [ ] Delete a recipe → toast appears in its grid slot; clicking Undo restores it; waiting 5s commits the deletion
- [ ] Delete recipe A, then within 5s delete recipe B → A commits, B's toast appears in its slot
- [ ] Delete the only remaining recipe → after 5s the meal plan becomes null and the empty state returns
- [ ] Clear shopping list → toast appears where the panel was; Undo restores items and checkmarks
- [ ] Empty pantry → toast appears in the empty-pantry placeholder; Undo restores items
- [ ] Toggle off API mode (with an API key set) → toast appears under the mode toggle in the header; Undo restores key + mode
- [ ] Generate a new plan over an existing one → toast still appears under the Generate button (unchanged)
- [ ] Error toasts (API error, storage error, sync error, image free-tier limit) still appear under the Generate button
- [ ] Mobile viewport: each toast above is visible without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)