### PR TITLE
refactor(layout): polish responsive layout below md

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -586,8 +586,8 @@ function App() {
 
       <main className="app-container flex flex-col gap-8">
         {/* Input Section */}
-        <section className="grid grid-cols-1 lg:grid-cols-3 gap-12 items-start">
-          <div className="lg:col-span-1 space-y-6 relative z-10">
+        <section className="flex flex-col md:flex-row gap-12 md:items-start">
+          <div className={`md:flex-1 md:max-w-sm md:min-w-0 space-y-6 relative z-10 ${mealPlan ? 'order-3 md:order-none' : ''}`}>
             <SettingsPanel
               ref={settingsPanelRef}
               optionsMinimized={optionsMinimized}
@@ -629,10 +629,9 @@ function App() {
             />
           </div>
 
-          <div className="lg:col-span-2 space-y-8">
-            {/* Divider between input and results sections - narrow viewport only */}
-            <hr className="lg:hidden border-t-2 border-primary/30 -mt-4" />
+          {mealPlan && <hr className="md:hidden order-2 border-t-2 border-primary/30" />}
 
+          <div className={`md:flex-1 md:min-w-0 space-y-8 ${mealPlan ? 'order-1 md:order-none' : 'hidden md:block'}`}>
             {mealPlan ? (
               <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
                 <ShoppingList

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -608,6 +608,7 @@ function App() {
               isMinimized={pantryMinimized}
               onToggleMinimize={handleTogglePantryMinimize}
               notification={notification}
+              autoFocus={!mealPlan}
             />
 
             <SpiceRack

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -193,16 +193,16 @@ export const Header: React.FC<HeaderProps> = ({
     return (
         <>
         <header className={`glass-panel !py-2 rounded-none border-x-0 border-t-0 sticky top-0 z-50 mb-4 backdrop-blur-xl transition-all duration-300 ${headerMinimized ? '!py-1' : ''}`}>
-            <div className="app-container flex flex-col items-center py-1">
-                <div className="flex flex-col items-start gap-3 relative w-max ml-12 sm:ml-0">
+            <div className="app-container flex flex-col items-start md:items-center py-1">
+                <div className="flex flex-col items-start gap-3 relative w-max ml-12 md:ml-0">
                     {/* Floating Leading Icon */}
-                    <div className={`absolute -left-14 sm:-left-16 top-0.5 p-2 bg-primary rounded-xl text-white shadow-lg shadow-primary/30 transition-all duration-300 ${headerMinimized ? 'scale-75' : ''}`}>
-                        <Utensils className={`transition-all duration-300 ${headerMinimized ? 'w-5 h-5' : 'w-6 h-6 sm:w-7 sm:h-7'}`} />
+                    <div className={`absolute -left-16 top-0.5 p-2 bg-primary rounded-xl text-white shadow-lg shadow-primary/30 transition-all duration-300 scale-75 ${headerMinimized ? '' : 'md:scale-100'}`}>
+                        <Utensils className={`transition-all duration-300 w-5 h-5 ${headerMinimized ? '' : 'md:w-7 md:h-7'}`} />
                     </div>
 
                     {/* Title with inline toggle button */}
                     <div className="flex items-center gap-3">
-                        <h1 className={`font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary transition-all duration-300 ${headerMinimized ? 'text-2xl' : 'text-4xl'}`}>
+                        <h1 className={`font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary transition-all duration-300 ${headerMinimized ? 'text-2xl' : 'text-2xl md:text-4xl'}`}>
                             AI Recipe Planner
                         </h1>
 

--- a/src/components/PantryInput.tsx
+++ b/src/components/PantryInput.tsx
@@ -20,6 +20,7 @@ interface PantryInputProps {
     isMinimized: boolean;
     onToggleMinimize: () => void;
     notification?: Notification | null;
+    autoFocus?: boolean;
 }
 
 export interface PantryInputRef {
@@ -34,7 +35,8 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
     onEmptyPantry,
     isMinimized,
     onToggleMinimize,
-    notification
+    notification,
+    autoFocus = true
 }, ref) => {
     const { t, useCopyPaste, apiKey, language } = useSettings();
     const tipsActive = !useCopyPaste && !!apiKey;
@@ -87,10 +89,13 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
         }
     }, [tipsActive, openTipForId]);
 
-    // Focus ingredient field on mount
+    // Focus ingredient field on mount, unless suppressed (e.g. when a meal
+    // plan is already shown above the inputs and focusing would scroll past it).
     useEffect(() => {
-        nameInputRef.current?.focus({ preventScroll: true });
-    }, []);
+        if (autoFocus) {
+            nameInputRef.current?.focus({ preventScroll: true });
+        }
+    }, [autoFocus]);
 
     const flushPendingInput = (): PantryItem | null => {
         if (name.trim()) {

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -130,7 +130,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
             {schemaJson && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: schemaJson }} />}
 
             <div className="flex items-start justify-between mb-6 gap-4">
-                <h3 className={`${isStandalone ? 'text-3xl' : 'text-2xl'} font-bold leading-tight flex-1`}>
+                <h3 className={`${isStandalone ? 'text-2xl md:text-3xl' : 'text-2xl'} font-bold leading-tight flex-1`}>
                     {recipe.title}
                 </h3>
                 <div className="flex items-center gap-2">
@@ -243,7 +243,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
             )}
 
             <div className="space-y-8 flex-grow">
-                <section>
+                <section className={isStandalone ? '' : 'hidden md:block'}>
                     <div className="flex items-center gap-2 mb-4 text-secondary">
                         <ListChecks size={20} />
                         <h4 className={`font-bold uppercase tracking-wider ${isStandalone ? 'text-sm' : 'text-xs'}`}>{t.ingredients}</h4>
@@ -309,7 +309,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
                     </section>
                 )}
 
-                <section>
+                <section className={isStandalone ? '' : 'hidden md:block'}>
                     <div className="flex items-center gap-2 mb-4 text-secondary">
                         <ChefHat size={20} />
                         <h4 className={`font-bold uppercase tracking-wider ${isStandalone ? 'text-sm' : 'text-xs'}`}>{t.instructions}</h4>
@@ -331,7 +331,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
                 </section>
 
                 {recipe.nutrition && (
-                    <div className="pt-4 border-t border-border-base/30">
+                    <div className={`pt-4 border-t border-border-base/30 ${isStandalone ? '' : 'hidden md:block'}`}>
                         <div className="flex items-center justify-between text-text-muted text-xs">
                             <span className="opacity-60">{t.nutritionPerServing}</span>
                             <div className="flex gap-3">

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -242,7 +242,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
                 </div>
             )}
 
-            <div className="space-y-8 flex-grow">
+            <div className="flex flex-col gap-8 flex-grow">
                 <section className={isStandalone ? '' : 'hidden md:block'}>
                     <div className="flex items-center gap-2 mb-4 text-secondary">
                         <ListChecks size={20} />

--- a/src/index.css
+++ b/src/index.css
@@ -133,7 +133,7 @@ button {
   }
 
   .app-container {
-    @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
+    @apply max-w-7xl mx-auto px-4 md:px-6;
   }
 
   .input-field {


### PR DESCRIPTION
## Summary
- Compact recipe cards below md (ingredients, instructions, nutrition hidden; title + time + image + delete + shopping list kept)
- Match standalone recipe title size to the overview below md, scaling up to text-3xl from md+
- Header: prevent title and logo from growing off-screen and from jumping horizontally on expand at narrow widths
- Page layout switches from single to two-column at md (was lg); input column capped at max-w-sm so panels stop growing well before two-column kicks in; recipes reordered above inputs in single-column when a meal plan exists; empty-state placeholder dropped below md
- app-container padding simplified to px-4 md:px-6 to eliminate the visible jumps at the sm and lg breakpoints

## Test plan
- [ ] Below md, overview cards show only title, time, image, delete, shopping list info
- [ ] Below md, standalone recipe view title matches overview size; md+ scales to text-3xl
- [ ] Header expand/collapse below md keeps title/logo on-screen with no horizontal shift
- [ ] At md, layout flips to two-column; input column never exceeds 384px; recipe column absorbs remaining width
- [ ] No empty-state placeholder below md when there is no meal plan
- [ ] Resize through sm (640px) and lg (1024px) — no padding jumps
- [ ] xl+ recipe grid still renders as 2 columns inside the results column

🤖 Generated with [Claude Code](https://claude.com/claude-code)