### PR TITLE
Migrate image generation to gemini-3.1-flash-image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.3.0
+**Current version**: 1.3.1
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "framer-motion": "^12.40.0",
         "lucide-react": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -70,7 +70,7 @@ export const URL_PARAMS = {
 export const API_CONFIG = {
     BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/models',
     MODEL: 'gemini-3-flash-preview',
-    IMAGE_MODEL: 'gemini-2.5-flash-image',
+    IMAGE_MODEL: 'gemini-3.1-flash-image',
     TIMEOUT_MS: 60000,
     KEY_URL: 'https://aistudio.google.com/app/apikey',
 } as const;


### PR DESCRIPTION
## Why

Google sent a deprecation notice: the **Imagen 4** endpoints (`imagen-4.0-generate-001`, `imagen-4.0-ultra-generate-001`, `imagen-4.0-fast-generate-001`) will be discontinued on **2026-08-17**, after which calls return `404 - Not Found`. The recommended migration path is **`gemini-3.1-flash-image`**.

## What this app actually uses

The app does **not** call the legacy Imagen `:predict` endpoints. Recipe images are generated via the Gemini `:generateContent` API in `generateRecipeImage` (`src/services/llm.ts`), previously using `gemini-2.5-flash-image`.

To stay ahead of deprecations and pick up Google's newer, more capable model at the same cost, this updates the single image-model constant to the recommended successor.

## Changes

- `src/constants/index.ts`: `IMAGE_MODEL` → `gemini-3.1-flash-image`
- Version bump `1.3.0` → `1.3.1` (`package.json`, `package-lock.json`, `AGENTS.md`)

`gemini-3.1-flash-image` uses the same `:generateContent` endpoint and inline-data response shape, so no other code changes are needed. `npm run build` passes.

## Note

The release tag (`v1.3.1`) is intentionally left out — per the project's release workflow, tagging happens after merge to `main`.

https://claude.ai/code/session_016iVZrw2edhtxNXm7YuE8tU

---
_Generated by [Claude Code](https://claude.ai/code/session_016iVZrw2edhtxNXm7YuE8tU)_