### PR TITLE
fix: persist recipe-card cooking progress and scope wake lock to focus view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "framer-motion": "^12.40.0",
         "lucide-react": "^1.17.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,9 +82,11 @@ function App() {
   // Single Shopping List View State (initialized from shared-link URL if present)
   const [viewShoppingList, setViewShoppingList] = useState<Ingredient[] | null>(initialSharedData.shoppingList);
 
-  // Wake Lock for keeping screen on during cooking
-  // Note: Auto-activation was removed because Safari/iOS requires explicit user gesture
-  // to acquire a wake lock. The button is prominently displayed for users to tap.
+  // Wake Lock for keeping screen on during cooking. Acquired automatically when
+  // a single recipe is opened and released when it is closed (see effect below),
+  // so the lock's lifetime matches the focus view — the only place with a toggle.
+  // Note: Safari/iOS may reject the request when it isn't tied to a user gesture;
+  // the hook fails gracefully and the in-card button remains for manual tapping.
   const wakeLock = useWakeLock();
 
   // Multi-device sync via GitHub Gist (opt-in).
@@ -216,6 +218,22 @@ function App() {
     prevViewRecipeRef.current = viewRecipe;
     prevViewShoppingListRef.current = viewShoppingList;
   }, [viewRecipe, viewShoppingList]);
+
+  // Keep the wake lock's lifetime tied to the single-recipe focus view: on by
+  // default when a recipe is opened, released when it's closed. The focus view
+  // is the only place exposing a toggle, so leaving the lock on after close
+  // would strand it with no way to turn it off.
+  useEffect(() => {
+    if (!wakeLock.isSupported) return;
+    if (viewRecipe) {
+      wakeLock.request();
+    } else {
+      wakeLock.release();
+    }
+    // Depend on the stable members, not the wakeLock object — it's a fresh
+    // literal every render and would otherwise re-run this effect constantly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewRecipe, wakeLock.isSupported, wakeLock.request, wakeLock.release]);
 
   useEffect(() => {
     const updateMetaTags = (title: string, description: string, url: string) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,21 +219,26 @@ function App() {
     prevViewShoppingListRef.current = viewShoppingList;
   }, [viewRecipe, viewShoppingList]);
 
-  // Keep the wake lock's lifetime tied to the single-recipe focus view: on by
-  // default when a recipe is opened, released when it's closed. The focus view
-  // is the only place exposing a toggle, so leaving the lock on after close
-  // would strand it with no way to turn it off.
+  // Keep the wake lock's lifetime tied to the single-recipe focus view: on when
+  // a recipe is open, released when it's closed. The focus view is the only
+  // place exposing a toggle, so leaving the lock on after close would strand it
+  // with no way to turn it off. openRecipeView already requests on the click
+  // gesture (for Safari); requesting here too is a harmless no-op that also
+  // covers the shared-link case, where a recipe is open on first load with no
+  // preceding gesture.
+  const isViewingRecipe = !!viewRecipe;
   useEffect(() => {
     if (!wakeLock.isSupported) return;
-    if (viewRecipe) {
+    if (isViewingRecipe) {
       wakeLock.request();
     } else {
       wakeLock.release();
     }
-    // Depend on the stable members, not the wakeLock object — it's a fresh
-    // literal every render and would otherwise re-run this effect constantly.
+    // request/release are stable useCallbacks; depending only on the boolean
+    // keeps the effect from re-running (and re-acquiring) on unrelated renders —
+    // e.g. when the user manually toggles the lock off inside the card.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewRecipe, wakeLock.isSupported, wakeLock.request, wakeLock.release]);
+  }, [isViewingRecipe, wakeLock.isSupported]);
 
   useEffect(() => {
     const updateMetaTags = (title: string, description: string, url: string) => {
@@ -279,10 +284,17 @@ function App() {
   const openRecipeView = useCallback((recipe: Recipe) => {
     savedScrollPositionRef.current = window.scrollY;
     setViewRecipe(recipe);
+    // Acquire the wake lock here, synchronously within the click handler, so the
+    // request is tied to the user gesture. Safari/iOS rejects a request made
+    // from the effect below because by then the gesture's activation is gone.
+    wakeLock.request();
     // Update URL without reload
     const shareUrl = generateShareUrl(URL_PARAMS.RECIPE, recipe);
     window.history.pushState({}, '', shareUrl);
-  }, []);
+    // wakeLock.request is a stable useCallback; depending on the wakeLock object
+    // itself would needlessly rebuild this handler every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wakeLock.request]);
 
   const openShoppingListView = useCallback((items: Ingredient[]) => {
     savedScrollPositionRef.current = window.scrollY;

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { Clock, ChefHat, AlertCircle, Maximize, Sun, SunDim, Trash2, ListChecks, X, Lightbulb, ChevronUp, ChevronDown, Image as ImageIcon, Loader2, RefreshCw } from 'lucide-react';
 import { motion } from 'framer-motion';
 import type { Recipe, Notification } from '../types';
 import { useSettings } from '../contexts/SettingsContext';
+import { useCookingProgress } from '../contexts/CookingProgressContext';
 import { UndoToast } from './ui/UndoToast';
 import { TimerChip } from './TimerChip';
 import { parseInstruction } from '../utils/parseTimers';
@@ -51,24 +52,23 @@ interface RecipeCardProps {
 
 export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenInNewTab = false, isStandalone = false, wakeLock, onDelete, onViewSingle, onClose, missingIngredientsMinimized = false, onToggleMissingIngredientsMinimize, onGenerateImage, onRemoveImage, onReplace, isImageLoading = false, imageError, imageUrl, pendingDelete = false, deleteNotification }) => {
     const { t } = useSettings();
-    const [struckIngredients, setStruckIngredients] = useState<Set<number>>(new Set());
-    const [activeStep, setActiveStep] = useState<number | null>(null);
+    // Crossed-off ingredients and the highlighted step live in a shared,
+    // in-memory store keyed by recipe identity, so progress survives closing
+    // and reopening the card (and is mirrored between the overview and focus
+    // views) — mirroring how the cooking timers persist across remounts.
+    const progressKey = recipe.id ?? recipe.title;
+    const { getProgress, toggleIngredient: toggleIngredientFor, toggleStep } = useCookingProgress();
+    const { struckIngredients, activeStep } = getProgress(progressKey);
 
-    const toggleIngredient = useCallback((idx: number) => {
-        setStruckIngredients(prev => {
-            const next = new Set(prev);
-            if (next.has(idx)) {
-                next.delete(idx);
-            } else {
-                next.add(idx);
-            }
-            return next;
-        });
-    }, []);
+    const toggleIngredient = useCallback(
+        (idx: number) => toggleIngredientFor(progressKey, idx),
+        [toggleIngredientFor, progressKey]
+    );
 
-    const toggleStepHighlight = useCallback((idx: number) => {
-        setActiveStep(prev => prev === idx ? null : idx);
-    }, []);
+    const toggleStepHighlight = useCallback(
+        (idx: number) => toggleStep(progressKey, idx),
+        [toggleStep, progressKey]
+    );
 
     // Memoize the JSON-LD schema to avoid regeneration on every render
     // Wrapped in try-catch to prevent malformed recipe data from crashing the component

--- a/src/contexts/CookingProgressContext.tsx
+++ b/src/contexts/CookingProgressContext.tsx
@@ -1,0 +1,72 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+
+/**
+ * Per-recipe cooking progress: which ingredients have been crossed off and
+ * which instruction step is highlighted. Like the cooking timers (see
+ * TimerContext), this state is kept in memory only — it survives a card
+ * remount (e.g. closing the focus view and reopening it) but intentionally
+ * does not persist across a reload, matching the lifetime of a cooking
+ * session. Keyed by the recipe's stable identity (`recipe.id ?? recipe.title`).
+ */
+
+export interface RecipeProgress {
+  struckIngredients: Set<number>;
+  activeStep: number | null;
+}
+
+// Shared read-only default for recipes with no recorded progress yet. Returning
+// the same reference keeps consumers stable until the user actually interacts.
+const EMPTY_PROGRESS: RecipeProgress = { struckIngredients: new Set(), activeStep: null };
+
+interface CookingProgressContextValue {
+  getProgress: (key: string) => RecipeProgress;
+  toggleIngredient: (key: string, idx: number) => void;
+  toggleStep: (key: string, idx: number) => void;
+}
+
+const CookingProgressContext = createContext<CookingProgressContextValue | undefined>(undefined);
+
+export const CookingProgressProvider = ({ children }: { children: ReactNode }) => {
+  const [progress, setProgress] = useState<Record<string, RecipeProgress>>({});
+
+  const getProgress = useCallback(
+    (key: string) => progress[key] ?? EMPTY_PROGRESS,
+    [progress]
+  );
+
+  const toggleIngredient = useCallback((key: string, idx: number) => {
+    setProgress((prev) => {
+      const current = prev[key] ?? EMPTY_PROGRESS;
+      const struckIngredients = new Set(current.struckIngredients);
+      if (struckIngredients.has(idx)) {
+        struckIngredients.delete(idx);
+      } else {
+        struckIngredients.add(idx);
+      }
+      return { ...prev, [key]: { ...current, struckIngredients } };
+    });
+  }, []);
+
+  const toggleStep = useCallback((key: string, idx: number) => {
+    setProgress((prev) => {
+      const current = prev[key] ?? EMPTY_PROGRESS;
+      return { ...prev, [key]: { ...current, activeStep: current.activeStep === idx ? null : idx } };
+    });
+  }, []);
+
+  const value = useMemo<CookingProgressContextValue>(
+    () => ({ getProgress, toggleIngredient, toggleStep }),
+    [getProgress, toggleIngredient, toggleStep]
+  );
+
+  return <CookingProgressContext.Provider value={value}>{children}</CookingProgressContext.Provider>;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useCookingProgress = () => {
+  const context = useContext(CookingProgressContext);
+  if (context === undefined) {
+    throw new Error('useCookingProgress must be used within a CookingProgressProvider');
+  }
+  return context;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import './index.css'
 import App from './App.tsx'
 import { SettingsProvider } from './contexts/SettingsContext'
 import { TimerProvider } from './contexts/TimerContext'
+import { CookingProgressProvider } from './contexts/CookingProgressContext'
 import { TimerTray } from './components/TimerTray'
 import { ErrorBoundary } from './components/ErrorBoundary'
 
@@ -12,8 +13,10 @@ createRoot(document.getElementById('root')!).render(
     <ErrorBoundary>
       <SettingsProvider>
         <TimerProvider>
-          <App />
-          <TimerTray />
+          <CookingProgressProvider>
+            <App />
+            <TimerTray />
+          </CookingProgressProvider>
         </TimerProvider>
       </SettingsProvider>
     </ErrorBoundary>


### PR DESCRIPTION
## Problem

Two inconsistencies around the recipe-card focus view, both reported while cooking:

1. **Progress is lost on close.** When you close a recipe card and reopen it, the cooking **timers keep running** (correct), but the **crossed-off ingredients** and the **highlighted step** are forgotten. Confusing, because they all feel like the same "cooking session" state.
2. **Wake lock is stranded on close.** The screen lock stays active after closing a card. Since the lock toggle only exists *inside* the focus view, there's no way to turn it off again from the overview — the screen stays locked.

## Changes

**Progress now persists like timers do.** Crossed-off ingredients and the highlighted step were local `useState` in `RecipeCard`, so they died with the component on unmount. They now live in a shared, in-memory `CookingProgressContext` keyed by recipe identity (`recipe.id ?? recipe.title`). This:
- survives closing/reopening the card (matching the timers' "survives remount, not reload" semantics), and
- mirrors progress between the overview card and the focus view of the same recipe.

**Wake lock lifetime is tied to the focus view.** A small effect in `App` acquires the lock when a single recipe is opened (on by default, as requested) and releases it when the card is closed. Reopening re-acquires it.

| Action | Before | After |
|---|---|---|
| Close card → reopen | crossed-off / step lost | **preserved** |
| Open card | lock off, tap to enable | lock **auto-on** |
| Close card | lock stays on (unreachable) | lock **released** |

## Notes
- Wake lock state is **not** persisted (in-memory only), consistent with the timer design.
- Safari/iOS may reject a wake-lock request that isn't tied to a user gesture; the `useWakeLock` hook already fails gracefully, and the in-card toggle remains for manual tapping. Chrome/Android auto-on works reliably.
- `npm run build` and `npm run lint` both pass (no test suite in this project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhpcptT48FT8irKHBfdCAc)_