### PR TITLE
fix: label timers with their containing sentence instead of the full step

### DIFF
--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -349,7 +349,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
                             >
                                 {segments.map((seg, si) =>
                                     seg.type === 'timer'
-                                        ? <TimerChip key={si} sourceId={`${recipe.id ?? recipe.title}::${i}::${si}`} text={seg.text} durationMs={seg.durationMs} label={step} />
+                                        ? <TimerChip key={si} sourceId={`${recipe.id ?? recipe.title}::${i}::${si}`} text={seg.text} durationMs={seg.durationMs} label={seg.sentence} />
                                         : <React.Fragment key={si}>{seg.text}</React.Fragment>
                                 )}
                             </li>

--- a/src/components/TimerChip.tsx
+++ b/src/components/TimerChip.tsx
@@ -14,7 +14,7 @@ interface TimerChipProps {
   /** The matched time phrase, e.g. "5 minutes". */
   text: string;
   durationMs: number;
-  /** The full recipe step, used as the timer's label in the tray. */
+  /** The instruction sentence containing the phrase, used as the timer's label in the tray. */
   label: string;
 }
 

--- a/src/components/TimerTray.tsx
+++ b/src/components/TimerTray.tsx
@@ -59,7 +59,7 @@ export const TimerTray: React.FC = () => {
                       }`}
                     >
                       <div className="flex-1 min-w-0">
-                        <p className="text-xs text-text-muted truncate" title={timer.label}>{timer.label}</p>
+                        <p className="text-xs text-text-muted line-clamp-2" title={timer.label}>{timer.label}</p>
                         <p
                           className={`font-mono tabular-nums text-sm font-semibold ${
                             isDone ? 'text-amber-600 dark:text-amber-400' : 'text-text-main'

--- a/src/contexts/TimerContext.tsx
+++ b/src/contexts/TimerContext.tsx
@@ -20,7 +20,7 @@ export interface CookingTimer {
    * after a remount — e.g. when the same recipe is opened in the focus view.
    */
   sourceId: string;
-  /** The recipe step the timer was started from — shown in the tray. */
+  /** The instruction sentence the timer was started from — shown in the tray. */
   label: string;
   totalMs: number;
   remainingMs: number;

--- a/src/utils/parseTimers.ts
+++ b/src/utils/parseTimers.ts
@@ -19,6 +19,8 @@ export interface TimerSegment {
   text: string;
   /** Duration in milliseconds. For ranges, the longer end is used. */
   durationMs: number;
+  /** The sentence of the instruction containing the match. Used as the timer's label. */
+  sentence: string;
 }
 
 export type InstructionSegment = TextSegment | TimerSegment;
@@ -81,6 +83,67 @@ export function formatDuration(ms: number): string {
   return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
 }
 
+// Abbreviations (lowercased, sans period) that commonly precede a period
+// mid-sentence in recipe text across EN/DE/ES/FR, so a period after them is
+// not a sentence boundary. Single letters ("z.", "B.") are excluded generically.
+const ABBREVIATIONS = new Set([
+  'ca', 'bzw', 'evtl', 'ggf', 'inkl', 'min', 'sek', 'std', 'tl', 'el', 'msp', 'pck', // DE
+  'approx', 'etc', 'oz', 'lb', 'lbs', 'tbsp', 'tsp', 'no', // EN
+  'aprox', 'cda', 'cdta', 'núm', // ES
+  'env', 'càs', 'càc', // FR
+]);
+
+/**
+ * Whether the period at `text[i]` ends a sentence. Errs on the side of "no":
+ * a missed boundary only makes the extracted sentence longer, never wrong.
+ */
+function isSentenceEndingPeriod(text: string, i: number): boolean {
+  // The word directly before the period must not be an abbreviation. Single
+  // letters count as abbreviations/initials ("z. B.", "°C.").
+  let w = i;
+  while (w > 0 && /\p{L}/u.test(text[w - 1])) w--;
+  const word = text.slice(w, i);
+  if (word.length === 1 || ABBREVIATIONS.has(word.toLowerCase())) return false;
+
+  // The period must be followed by whitespace and an uppercase letter (a
+  // following digit or lowercase letter means "ca. 10", "1.5", "10 Min. mehr").
+  let j = i + 1;
+  while (j < text.length && /["')\]]/.test(text[j])) j++;
+  if (j >= text.length) return true;
+  if (!/\s/.test(text[j])) return false;
+  while (j < text.length && /\s/.test(text[j])) j++;
+  return j >= text.length || /\p{Lu}/u.test(text[j]);
+}
+
+/** Whether `text[i]` is a sentence boundary. */
+const isBoundary = (text: string, i: number): boolean => {
+  const ch = text[i];
+  return ch === '\n' || ch === '!' || ch === '?' || (ch === '.' && isSentenceEndingPeriod(text, i));
+};
+
+/**
+ * Extracts the sentence of `text` containing the range [start, end). Used to
+ * label a timer with just the instruction sentence its time phrase sits in,
+ * e.g. "Die Sauce ca. 10 Minuten köcheln lassen." out of a multi-sentence step.
+ */
+export function extractSentence(text: string, start: number, end: number): string {
+  let from = 0;
+  for (let i = start - 1; i >= 0; i--) {
+    if (isBoundary(text, i)) {
+      from = i + 1;
+      break;
+    }
+  }
+  let to = text.length;
+  for (let i = end; i < text.length; i++) {
+    if (isBoundary(text, i)) {
+      to = text[i] === '\n' ? i : i + 1;
+      break;
+    }
+  }
+  return text.slice(from, to).trim();
+}
+
 /**
  * Splits an instruction string into ordered text and timer segments.
  * Matched durations become {@link TimerSegment}s; everything else stays text.
@@ -104,8 +167,13 @@ export function parseInstruction(text: string | null | undefined): InstructionSe
     if (match.index > lastIndex) {
       segments.push({ type: 'text', text: safeText.slice(lastIndex, match.index) });
     }
-    segments.push({ type: 'timer', text: matched, durationMs });
     lastIndex = match.index + matched.length;
+    segments.push({
+      type: 'timer',
+      text: matched,
+      durationMs,
+      sentence: extractSentence(safeText, match.index, lastIndex),
+    });
   }
 
   if (lastIndex < safeText.length) {

--- a/src/utils/parseTimers.ts
+++ b/src/utils/parseTimers.ts
@@ -93,6 +93,10 @@ const ABBREVIATIONS = new Set([
   'env', 'càs', 'càc', 'cuil', 'pers', // FR
 ]);
 
+// Closing quotes/brackets that may sit between a sentence-ending period and
+// the following whitespace (`…lassen.“ Danach`, `…end.” Then`).
+const CLOSERS = /["'’”“‘«»‹›)\]}]/;
+
 /**
  * Whether the period at `text[i]` ends a sentence. Errs on the side of "no":
  * a missed boundary only makes the extracted sentence longer, never wrong.
@@ -108,7 +112,7 @@ function isSentenceEndingPeriod(text: string, i: number): boolean {
   // The period must be followed by whitespace and an uppercase letter (a
   // following digit or lowercase letter means "ca. 10", "1.5", "10 Min. mehr").
   let j = i + 1;
-  while (j < text.length && /["'’”“‘«»‹›)\]}]/.test(text[j])) j++;
+  while (j < text.length && CLOSERS.test(text[j])) j++;
   if (j >= text.length) return true;
   if (!/\s/.test(text[j])) return false;
   while (j < text.length && /\s/.test(text[j])) j++;
@@ -134,12 +138,17 @@ export function extractSentence(text: string, start: number, end: number): strin
       break;
     }
   }
-  // Skip the previous sentence's trailing quotes/brackets (e.g. `…rühren.“ Die`).
-  while (from < start && /["'’”“‘«»‹›)\]}\s]/.test(text[from])) from++;
+  // Step past the previous sentence's trailing quotes/brackets, then the
+  // inter-sentence whitespace — in that order, so an opening quote of this
+  // sentence (`…rühren! „Die Sauce…`) is left intact.
+  while (from < start && CLOSERS.test(text[from])) from++;
+  while (from < start && /\s/.test(text[from])) from++;
   let to = text.length;
   for (let i = end; i < text.length; i++) {
     if (isBoundary(text, i)) {
       to = text[i] === '\n' ? i : i + 1;
+      // Keep this sentence's own trailing quotes/brackets (`…lassen.“`).
+      while (to < text.length && CLOSERS.test(text[to])) to++;
       break;
     }
   }

--- a/src/utils/parseTimers.ts
+++ b/src/utils/parseTimers.ts
@@ -87,10 +87,10 @@ export function formatDuration(ms: number): string {
 // mid-sentence in recipe text across EN/DE/ES/FR, so a period after them is
 // not a sentence boundary. Single letters ("z.", "B.") are excluded generically.
 const ABBREVIATIONS = new Set([
-  'ca', 'bzw', 'evtl', 'ggf', 'inkl', 'min', 'sek', 'std', 'tl', 'el', 'msp', 'pck', // DE
-  'approx', 'etc', 'oz', 'lb', 'lbs', 'tbsp', 'tsp', 'no', // EN
+  'ca', 'bzw', 'evtl', 'ggf', 'inkl', 'min', 'sek', 'std', 'tl', 'el', 'msp', 'pck', 'st', 'stk', // DE
+  'approx', 'etc', 'oz', 'lb', 'lbs', 'tbsp', 'tsp', 'no', 'pkg', 'pkgs', 'fl', 'qt', 'pt', 'gal', // EN
   'aprox', 'cda', 'cdta', 'núm', // ES
-  'env', 'càs', 'càc', // FR
+  'env', 'càs', 'càc', 'cuil', 'pers', // FR
 ]);
 
 /**
@@ -108,7 +108,7 @@ function isSentenceEndingPeriod(text: string, i: number): boolean {
   // The period must be followed by whitespace and an uppercase letter (a
   // following digit or lowercase letter means "ca. 10", "1.5", "10 Min. mehr").
   let j = i + 1;
-  while (j < text.length && /["')\]]/.test(text[j])) j++;
+  while (j < text.length && /["'’”“‘«»‹›)\]}]/.test(text[j])) j++;
   if (j >= text.length) return true;
   if (!/\s/.test(text[j])) return false;
   while (j < text.length && /\s/.test(text[j])) j++;
@@ -134,6 +134,8 @@ export function extractSentence(text: string, start: number, end: number): strin
       break;
     }
   }
+  // Skip the previous sentence's trailing quotes/brackets (e.g. `…rühren.“ Die`).
+  while (from < start && /["'’”“‘«»‹›)\]}\s]/.test(text[from])) from++;
   let to = text.length;
   for (let i = end; i < text.length; i++) {
     if (isBoundary(text, i)) {


### PR DESCRIPTION
## Problem

Timers in the floating tray (bottom right) were labelled with the **entire recipe step** they were started from. Steps are almost always far too long for the tray, and the single-line truncation showed only the beginning of the step — often a completely different action than the one being timed. When a timer rang, the label didn't answer the practical question: *which burner do I turn off?*

## Solution

Label each timer with just the **sentence containing the matched time phrase**, e.g. `Sauce ca. 10 Minuten köcheln lassen.` — the sentence with the duration is almost always the one describing the activity being timed.

- `parseTimers.ts`: new `extractSentence` helper scans outward from the matched time phrase to the nearest real sentence boundary. Boundary detection is abbreviation-aware so periods in `ca.`, `z. B.`, `approx.`, `env.`, `aprox.`, decimals (`1.5`), and unit abbreviations (`Min.`) don't split the sentence. It deliberately fails open: a missed boundary only makes the label longer, never wrong or misleadingly short. `TimerSegment` carries the sentence as a new `sentence` field.
- `RecipeCard.tsx`: passes `seg.sentence` instead of the full step as the timer label.
- `TimerTray.tsx`: label now wraps to two lines (`line-clamp-2` instead of `truncate`) so a typical sentence is fully readable; full text remains available as tooltip.
- Timers from multiple time phrases in the same step now get distinct labels too, since the phrases practically always sit in different sentences.

## Verification

- Sentence extraction exercised against 16 cases across all four supported languages (EN/DE/ES/FR), including abbreviation traps (`ca.`, `z. B.`, `Min.`, `approx.`, `aprox.`, `env.`), decimals, ranges, `!`/newline boundaries, and the intentional fail-open cases — all pass.
- `npm run build` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf5DvrwdAMS4C1QUnAC8WS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf5DvrwdAMS4C1QUnAC8WS)_