### PR TITLE
ci(dependabot): ignore TypeScript major updates until typescript-eslint supports TS7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "weekly"
       day: "friday"
     open-pull-requests-limit: 10
+    ignore:
+      # typescript-eslint does not yet support TypeScript 7
+      # (peer range >=4.8.4 <6.1.0). Remove once it does.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         patterns:


### PR DESCRIPTION
## Why

Without this, Dependabot re-proposes the TypeScript 6→7 major bump on every weekly run. Because TypeScript 7 is outside `typescript-eslint`'s supported peer range (`>=4.8.4 <6.1.0`), the whole `dev-dependencies` group PR fails `npm ci` with `ERESOLVE` — a recurring red PR that can never merge (this is what happened with #259).

## Change

Add an `ignore` rule to `.github/dependabot.yml` that skips **major** TypeScript updates only:

```yaml
    ignore:
      - dependency-name: "typescript"
        update-types: ["version-update:semver-major"]
```

- TypeScript 6.x patch/minor updates still flow normally (no loss of security fixes).
- No more auto-generated TS7 group PRs that break CI.

## Follow-up

Remove this rule once `typescript-eslint` ships a release that supports TypeScript 7 (upstream tracking: [typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518)), then let Dependabot do the major upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHuZXcZjJG9tkdbKAxeySn

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHuZXcZjJG9tkdbKAxeySn)_