### PR TITLE
feat: switch recipe model to gemini-3.6-flash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.5.0
+**Current version**: 1.5.1
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "framer-motion": "^12.42.2",
         "lucide-react": "^1.24.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -75,7 +75,7 @@ export const URL_PARAMS = {
  */
 export const API_CONFIG = {
     BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/models',
-    MODEL: 'gemini-3-flash-preview',
+    MODEL: 'gemini-3.6-flash',
     IMAGE_MODEL: 'gemini-2.5-flash-image',
     TIMEOUT_MS: 60000,
     KEY_URL: 'https://aistudio.google.com/app/apikey',


### PR DESCRIPTION
## Summary

Switches the text/recipe generation model from the preview model `gemini-3-flash-preview` to the now generally available (production-ready) **`gemini-3.6-flash`**, released July 21, 2026.

Motivation:
- The app was pinned to a **preview** model, which Google eventually retires. `gemini-3.6-flash` is the GA successor.
- Improved reasoning and better token efficiency for recipe generation.
- Cost stays negligible for personal use (well under ~2.5¢ per meal-plan request); recipe photos remain the dominant cost driver, not text.

The default `thinkingLevel` (`medium`) is used — no `thinkingConfig` was added. `gemini-3.6-flash` only supports `medium`/`high`, so there is no lower level to save on, and recipe JSON generation does not benefit from `high`.

## Changes

- `src/constants/index.ts`: `API_CONFIG.MODEL` → `gemini-3.6-flash`
- Version bump `1.5.0` → `1.5.1` (`package.json`, `package-lock.json`, `AGENTS.md`)

## Testing

- `npm run build` ✅
- `npm run lint` ✅

## Notes

The image model (`gemini-2.5-flash-image`) is unchanged in this PR. It is slated for deprecation on 2026-10-16 and will need a separate migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZivuR6Y8sjDA9idhxcSDm)_