### PR TITLE
feat: switch image model to gemini-3.1-flash-image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.5.1
+**Current version**: 1.5.2
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "framer-motion": "^12.42.2",
         "lucide-react": "^1.24.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -76,7 +76,7 @@ export const URL_PARAMS = {
 export const API_CONFIG = {
     BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/models',
     MODEL: 'gemini-3.6-flash',
-    IMAGE_MODEL: 'gemini-2.5-flash-image',
+    IMAGE_MODEL: 'gemini-3.1-flash-image',
     TIMEOUT_MS: 60000,
     KEY_URL: 'https://aistudio.google.com/app/apikey',
 } as const;


### PR DESCRIPTION
## Summary

Migrates the recipe photo generation model from **`gemini-2.5-flash-image`** — which is scheduled for deprecation on **2026-10-16** — to its drop-in successor **`gemini-3.1-flash-image`** (Nano Banana 2).

Why `gemini-3.1-flash-image`:
- **Drop-in**: same `generateContent` API shape and `inlineData` response format, so `generateRecipeImage` and all of its error handling (including the free-tier zero-limit path) work unchanged. Only the `IMAGE_MODEL` constant changes.
- **Same pricing tier** as the deprecated model (~$0.039 per 1024px image), so no cost regression.
- Image models have no free tier — unchanged; this migration does not affect the existing paid-tier requirement for the image feature.

Cheaper alternatives (`imagen-4-fast` at $0.02/image, or `gemini-3.1-flash-lite-image`) were considered but rejected for this PR: Imagen uses a different `:predict` API and response format (larger rewrite), and the goal here is a low-risk, like-for-like deprecation fix.

## Changes

- `src/constants/index.ts`: `API_CONFIG.IMAGE_MODEL` → `gemini-3.1-flash-image`
- Version bump `1.5.1` → `1.5.2` (`package.json`, `package-lock.json`, `AGENTS.md`)

## Testing

- `npm run build` ✅
- `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZivuR6Y8sjDA9idhxcSDm)_