### PR TITLE
feat: start cooking timers straight from the chat's answers

### DIFF
--- a/src/components/RecipeChat.tsx
+++ b/src/components/RecipeChat.tsx
@@ -4,8 +4,19 @@ import { MessageCircle, X, Send, Loader2, AlertCircle, RefreshCw, Eraser } from 
 import { useSettings } from '../contexts/SettingsContext';
 import { useCookingProgress } from '../contexts/CookingProgressContext';
 import { chatKeyFor, MAX_CHAT_INPUT_LENGTH, type RecipeChatController } from '../hooks/useRecipeChat';
+import { parseInstruction } from '../utils/parseTimers';
+import { TimerChip } from './TimerChip';
 import type { RecipeChatContext } from '../services/llm';
 import type { Recipe } from '../types';
+
+/**
+ * Bottom offset for the chat's floats. The chat sits bottom-left and the timer
+ * tray bottom-right; together they need 384 + 288 + gutters ≈ 704px, so below
+ * `md` (768px) they would overlap. There, the chat rides on top of the tray's
+ * published height instead — the tray keeps the corner, since a running
+ * countdown must never be covered by a conversation.
+ */
+const STACK_ABOVE_TRAY = 'bottom-[calc(1rem+var(--timer-tray-height,0px))] md:bottom-4';
 
 interface RecipeChatProps {
     /** The recipe being cooked — handed to the model as context. */
@@ -100,7 +111,7 @@ export const RecipeChat: React.FC<RecipeChatProps> = ({ recipe, chat }) => {
                         exit={{ opacity: 0, scale: 0.8 }}
                         onClick={() => setIsOpen(true)}
                         aria-label={t.recipeChat.open}
-                        className="fixed bottom-4 left-4 z-40 h-14 w-14 rounded-full bg-primary text-white shadow-lg hover:bg-primary-hover transition-colors flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+                        className={`fixed left-4 z-40 h-14 w-14 rounded-full bg-primary text-white shadow-lg hover:bg-primary-hover transition-colors flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${STACK_ABOVE_TRAY}`}
                     >
                         <MessageCircle size={24} />
                         {messages.length > 0 && (
@@ -119,7 +130,7 @@ export const RecipeChat: React.FC<RecipeChatProps> = ({ recipe, chat }) => {
                         initial={{ opacity: 0, y: 20 }}
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: 20 }}
-                        className="fixed bottom-4 left-4 z-40 w-96 max-w-[calc(100vw-2rem)]"
+                        className={`fixed left-4 z-40 w-96 max-w-[calc(100vw-2rem)] ${STACK_ABOVE_TRAY}`}
                     >
                         <div
                             role="dialog"
@@ -169,16 +180,32 @@ export const RecipeChat: React.FC<RecipeChatProps> = ({ recipe, chat }) => {
                                     </p>
                                 )}
 
-                                {messages.map((message, idx) => (
+                                {messages.map((message) => (
                                     <div
-                                        key={`${message.role}-${idx}`}
+                                        key={message.id}
                                         className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap ${
                                             message.role === 'user'
                                                 ? 'self-end bg-primary/10 text-text-main'
                                                 : 'self-start bg-white/60 dark:bg-black/25 border border-border-base/30 text-text-main'
                                         }`}
                                     >
-                                        {message.text}
+                                        {/* Time phrases in a reply become the same one-tap timers as
+                                            in a recipe step. Only replies are parsed — a chip inside
+                                            the user's own question would be noise. */}
+                                        {message.role === 'model'
+                                            ? parseInstruction(message.text).map((segment, si) =>
+                                                segment.type === 'timer'
+                                                    ? <TimerChip
+                                                        key={si}
+                                                        sourceId={`${message.id}::${si}`}
+                                                        text={segment.text}
+                                                        durationMs={segment.durationMs}
+                                                        followUpMs={segment.followUpMs}
+                                                        label={segment.sentence}
+                                                    />
+                                                    : <React.Fragment key={si}>{segment.text}</React.Fragment>
+                                            )
+                                            : message.text}
                                     </div>
                                 ))}
 

--- a/src/components/RecipeChat.tsx
+++ b/src/components/RecipeChat.tsx
@@ -16,7 +16,7 @@ import type { Recipe } from '../types';
  * published height instead — the tray keeps the corner, since a running
  * countdown must never be covered by a conversation.
  */
-const STACK_ABOVE_TRAY = 'bottom-[calc(1rem+var(--timer-tray-height,0px))] md:bottom-4';
+const STACK_ABOVE_TRAY = 'bottom-[calc(1rem_+_var(--timer-tray-height,0px))] md:bottom-4';
 
 interface RecipeChatProps {
     /** The recipe being cooked — handed to the model as context. */

--- a/src/components/TimerTray.tsx
+++ b/src/components/TimerTray.tsx
@@ -28,9 +28,15 @@ export const TimerTray: React.FC = () => {
       root.style.setProperty('--timer-tray-height', '0px');
       return;
     }
-    // The extra 8px is the gap below the float stacked on top, kept here so the
-    // consumer is a plain `calc(1rem + var(...))`.
-    const publishHeight = () => root.style.setProperty('--timer-tray-height', `${el.offsetHeight + 8}px`);
+    // A non-zero height carries an extra 8px — the gap below the float stacked
+    // on top — so the consumer stays a plain `calc(1rem + var(...))`. Height 0
+    // must stay exactly 0: the observer also fires with 0 when AnimatePresence
+    // finally detaches the tray, and adding the gap there would strand the
+    // float 8px above its resting position for the rest of the session.
+    const publishHeight = () => {
+      const height = el.offsetHeight;
+      root.style.setProperty('--timer-tray-height', height > 0 ? `${height + 8}px` : '0px');
+    };
     publishHeight();
     // The tray grows and shrinks as timers are added, finish, or are dismissed.
     const observer = new ResizeObserver(publishHeight);

--- a/src/components/TimerTray.tsx
+++ b/src/components/TimerTray.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Timer as TimerIcon, Pause, Play, X, Volume2, VolumeX } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
@@ -9,15 +9,42 @@ import { formatDuration } from '../utils/parseTimers';
  * Floating tray listing all active cooking timers, each labelled with the
  * recipe step it came from. Mounted once at the app root; renders nothing when
  * no timers are running.
+ *
+ * Publishes its own height as `--timer-tray-height` on the document root so
+ * other bottom-anchored floats can stack above it on screens too narrow to sit
+ * beside it (see RecipeChat). The tray is the one that stays put: a countdown
+ * is more time-critical than anything that would cover it.
  */
 export const TimerTray: React.FC = () => {
   const { t } = useSettings();
   const { timers, muted, toggleMuted, pauseTimer, resumeTimer, cancelTimer } = useTimers();
+  const trayRef = useRef<HTMLDivElement>(null);
+  const hasTimers = timers.length > 0;
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const el = trayRef.current;
+    if (!el) {
+      root.style.setProperty('--timer-tray-height', '0px');
+      return;
+    }
+    // The extra 8px is the gap below the float stacked on top, kept here so the
+    // consumer is a plain `calc(1rem + var(...))`.
+    const publishHeight = () => root.style.setProperty('--timer-tray-height', `${el.offsetHeight + 8}px`);
+    publishHeight();
+    // The tray grows and shrinks as timers are added, finish, or are dismissed.
+    const observer = new ResizeObserver(publishHeight);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      root.style.setProperty('--timer-tray-height', '0px');
+    };
+  }, [hasTimers]);
 
   return (
     <AnimatePresence>
       {timers.length > 0 && (
-        <div className="fixed bottom-4 right-4 z-50 w-72 max-w-[calc(100vw-2rem)]">
+        <div ref={trayRef} className="fixed bottom-4 right-4 z-50 w-72 max-w-[calc(100vw-2rem)]">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}

--- a/src/hooks/useRecipeChat.ts
+++ b/src/hooks/useRecipeChat.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useSettings } from '../contexts/SettingsContext';
 import { chatAboutRecipe, type ChatMessage, type RecipeChatContext } from '../services/llm';
+import { generateId } from '../utils/idGenerator';
 import type { Recipe } from '../types';
 
 /**
@@ -18,14 +19,26 @@ import type { Recipe } from '../types';
 
 export const chatKeyFor = (recipe: Recipe): string => recipe.id ?? recipe.title;
 
-const EMPTY_HISTORY: readonly ChatMessage[] = [];
+/**
+ * A transcript entry: the wire-level message plus a UI-only identity.
+ *
+ * The id anchors the timer chips parsed out of a reply — a chip's `sourceId`
+ * must stay stable across remounts but must never be reused, and a positional
+ * key would be: clearing the chat and asking again puts a fresh reply at the
+ * same index, where it would adopt the earlier message's running timer.
+ */
+export interface StoredChatMessage extends ChatMessage {
+    id: string;
+}
+
+const EMPTY_HISTORY: readonly StoredChatMessage[] = [];
 
 /** Cap on a single question, mirroring the app's other free-text limits. */
 export const MAX_CHAT_INPUT_LENGTH = 500;
 
 export function useRecipeChat() {
     const { apiKey, language, t } = useSettings();
-    const [histories, setHistories] = useState<Record<string, ChatMessage[]>>({});
+    const [histories, setHistories] = useState<Record<string, StoredChatMessage[]>>({});
     const [errors, setErrors] = useState<Record<string, string>>({});
     const [pendingKey, setPendingKey] = useState<string | null>(null);
     // Synchronous in-flight guard, so a double-tap on Send can't slip past a
@@ -37,7 +50,7 @@ export function useRecipeChat() {
     const generationRef = useRef(0);
 
     const getMessages = useCallback(
-        (key: string): readonly ChatMessage[] => histories[key] ?? EMPTY_HISTORY,
+        (key: string): readonly StoredChatMessage[] => histories[key] ?? EMPTY_HISTORY,
         [histories]
     );
 
@@ -52,7 +65,7 @@ export function useRecipeChat() {
      */
     const run = useCallback(async (
         recipe: Recipe,
-        history: ChatMessage[],
+        history: StoredChatMessage[],
         context: RecipeChatContext
     ): Promise<void> => {
         const key = chatKeyFor(recipe);
@@ -73,7 +86,7 @@ export function useRecipeChat() {
                 errorTranslations: t.errors,
             });
             if (generationRef.current !== generation) return;
-            setHistories(prev => ({ ...prev, [key]: [...(prev[key] ?? []), { role: 'model', text: reply }] }));
+            setHistories(prev => ({ ...prev, [key]: [...(prev[key] ?? []), { id: generateId(), role: 'model', text: reply }] }));
         } catch (err) {
             if (generationRef.current !== generation) return;
             const message = err instanceof Error ? err.message : t.errors.unexpectedError;
@@ -88,7 +101,7 @@ export function useRecipeChat() {
         const trimmed = text.trim().slice(0, MAX_CHAT_INPUT_LENGTH);
         if (!trimmed || inFlightRef.current) return;
         const key = chatKeyFor(recipe);
-        const history: ChatMessage[] = [...(histories[key] ?? []), { role: 'user', text: trimmed }];
+        const history: StoredChatMessage[] = [...(histories[key] ?? []), { id: generateId(), role: 'user', text: trimmed }];
         setHistories(prev => ({ ...prev, [key]: history }));
         void run(recipe, history, context);
     }, [histories, run]);

--- a/src/services/llm.ts
+++ b/src/services/llm.ts
@@ -731,6 +731,7 @@ RULES:
 - Reply in ${language}.
 - When addressing the reader in a language with a T-V distinction, ALWAYS use the informal second person singular: "du" in German, "tu" in French, "tú" in Spanish. Never use the formal form.
 - Be brief: 1-4 sentences unless more detail is explicitly requested. The user is standing at the stove, usually reading on a phone.
+- State any duration as a concrete number with a unit ('10 minutes', '1-2 hours'), never as a vague phrase ('a few minutes'), so the app can offer it as a one-tap timer. Do not invent precision: if the time genuinely depends on the situation, describe what to look for instead of guessing a number.
 - Plain prose only. No markdown, no bullet lists, no headings, no code blocks.
 - Answer from the recipe above whenever it covers the question. Otherwise fall back on general cooking knowledge and make clear that you are going beyond the recipe.
 - You cannot edit the recipe, the shopping list, or anything else in the app. If the user asks for a change, describe it in words so they can apply it themselves.

--- a/src/utils/parseTimers.ts
+++ b/src/utils/parseTimers.ts
@@ -41,8 +41,11 @@ const FRACTION_CHARS = Object.keys(FRACTIONS).join('');
 // ("1½", "1.5", "1,5"), or a lone fraction glyph ("½").
 const NUMBER = `(?:\\d+(?:[.,]\\d+)?\\s*[${FRACTION_CHARS}]?|[${FRACTION_CHARS}])`;
 
-// Optional second number forming a range ("3-4", "3 to 4", "3 bis 4", "3 à 4").
-const RANGE = `(?:\\s*(?:-|–|—|to|bis|à)\\s*(${NUMBER}))?`;
+// Optional second number forming a range ("3-4", "3 to 4", "3 bis 4", "3 à 4",
+// "3 a 4"). The bare Spanish "a" is safe despite being a common word: it only
+// counts when it sits between two numbers that are themselves followed by a
+// time unit.
+const RANGE = `(?:\\s*(?:-|–|—|to|bis|à|a)\\s*(${NUMBER}))?`;
 
 // Unit words across EN/DE/ES/FR. Longer alternatives come first so "minutes"
 // wins over a bare "min". Bare single letters ("h", "s") are matched last and


### PR DESCRIPTION
Follow-up to #270. When the kitchen assistant says "noch etwa 12 Minuten", that phrase is now the same one-tap timer as a duration in a recipe step.

## Why this was cheap

`parseInstruction` in `parseTimers.ts` takes any string — nothing about it is recipe-specific — and `TimerChip` derives its state from the global timer context rather than local state. So replies just run through the existing pipeline, and everything comes along for free: the tray, the sound, pause/resume, and the range behaviour (`3-4 Minuten` starts at 3 and appends a 1-minute follow-up).

The tray label lands well without extra work. `extractSentence` already pulls the sentence around the match, so the tray shows *"Lass die Karotten noch etwa 12 Minuten rösten."* rather than a bare countdown.

## Decisions worth flagging

**Only replies are parsed.** A timer chip inside the user's own typed question would be noise.

**Message ids, not positions.** A chip's `sourceId` must be stable across remounts but must never be reused. A positional key collides: start a timer from message 1, clear the chat, ask again — the new reply lands at index 1 and would adopt the old running timer. Each transcript entry now carries a `generateId()` id, and `sourceId` is `${message.id}::${segmentIndex}`. `StoredChatMessage extends ChatMessage` keeps this UI concern out of the wire type.

**A prompt line for concrete durations.** Without it the model happily says "ein paar Minuten" and there is nothing to parse. The rule asks for a number plus unit *and* explicitly warns against inventing precision — if the time genuinely depends, it should describe what to look for instead.

## Mobile overlap

Below `md` the chat panel and the timer tray cannot sit side by side: 384 + 288 + gutters ≈ 704px. This was already true in #270 but mattered little; now that the chat is itself a way to start timers, having a conversation cover the countdown it just started would be perverse.

`TimerTray` now measures itself with a `ResizeObserver` and publishes `--timer-tray-height` on the document root; the chat's floats consume it via `bottom-[calc(1rem+var(--timer-tray-height,0px))] md:bottom-4`. The tray keeps the corner and the chat rides above it, because a running countdown outranks a conversation. The var tracks the tray growing and shrinking as timers are added or dismissed, and resets to `0px` when the tray unmounts.

Note that the closed chat button also lifts. On a 390px phone it would not strictly collide, so it hops up slightly when a timer starts — but below ~376px it *would* be buried behind the tray, and an unreachable chat button is worse than a small movement with a visible cause.

## Verification

`npm run lint` and `npm run build` pass. The two arbitrary-value classes were checked in the built CSS (`bottom:calc(1rem + var(--timer-tray-height,0px))` and the `md:` override at 48rem). Driven in Chromium via Playwright against stubbed replies:

- A reply containing `12 Minuten` and `3-4 Minuten` renders two chips; tapping the first starts a countdown (`11:59`) and the tray shows the full sentence as its label.
- Start a timer, clear the chat, ask again: the new chip reads `25 Minuten` rather than inheriting the old countdown, and the original timer keeps running in the tray.
- At 390×844 with a timer running and the chat open, the panel's bottom edge is at 688px and the tray's top at 696px — measured, no overlap.

Not verified: a live round-trip against the real Gemini endpoint, which needs a valid API key. In particular, how reliably the model emits parseable durations under the new prompt rule is a real-world question.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dgiGY7iXn23Tmoa4bCH9y)_