### PR TITLE
chore: bump version to 1.8.0 and tag releases automatically

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,41 @@
+name: Tag release
+
+# Creates the vX.Y.Z tag whenever package.json's version reaches main without
+# a matching tag. The tag push then triggers release.yml.
+#
+# The GitHub App token is required, not cosmetic: a tag pushed with the default
+# GITHUB_TOKEN does not trigger other workflows, so release.yml would never run.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Create tag if the version is not tagged yet
+        run: |
+          VERSION="v$(node -p "require('./package.json').version")"
+          if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "$VERSION is already tagged, nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "Release version ${VERSION#v}"
+          git push origin "$VERSION"
+          echo "Tagged $VERSION." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,6 +11,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Read-only is enough: checkout and the tag push both authenticate with the
+# app token, not with GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   tag:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.7.0
+**Current version**: 1.8.0
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 
@@ -20,11 +20,14 @@ This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 
 ### Version Management Workflow
 
-1. Update version in `package.json` and `AGENTS.md`
+1. Update version in `package.json` (use `npm version X.Y.Z --no-git-tag-version` so `package-lock.json` stays in sync) and in `AGENTS.md`
 2. Commit changes with message: `chore: bump version to X.Y.Z`
-3. Create git tag: `git tag -a vX.Y.Z -m "Release version X.Y.Z"`
-4. Push commits and tags: `git push && git push --tags`
-5. GitHub Release is automatically created with a GitHub workflow.
+3. Get the commit onto `main` (push, or merge a pull request)
+4. `tag-release.yml` creates the `vX.Y.Z` tag automatically, which triggers `release.yml` to publish the GitHub Release.
+
+Tagging by hand is no longer necessary — the version in `package.json` is what
+drives a release. An existing tag is never overwritten, so re-running the
+workflow on an already-released version is a no-op.
 
 ## Implementation Guidelines
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "framer-motion": "^12.42.2",
         "lucide-react": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What

Releases are now driven by the version in `package.json` instead of a manually pushed tag, and the version is bumped to 1.8.0 for the seasonality feature from #273.

- **New `.github/workflows/tag-release.yml`** — on every push to `main` it reads `package.json`'s version and creates the matching `vX.Y.Z` tag if it doesn't exist yet. That tag push triggers the existing `release.yml`.
- **1.7.0 → 1.8.0** in `package.json`, `package-lock.json` and `AGENTS.md`.
- **`AGENTS.md` release workflow updated** to describe the new flow.

## Why

The old flow needed `git tag` + `git push --tags` from a local checkout, on a commit that only exists on `main` after a merge. That step is unreachable from a sandboxed agent session, so version bumps kept stalling out. Deriving the tag from `package.json` moves the decision into the reviewable diff and removes the manual step for everyone.

## The app token is load-bearing

The workflow mints a GitHub App token instead of using the default `GITHUB_TOKEN`. That is not cosmetic: **a tag pushed with `GITHUB_TOKEN` does not trigger other workflows** — GitHub suppresses those events to prevent recursion — so `release.yml` would never fire. It reuses the same `vars.APP_CLIENT_ID` / `secrets.APP_PRIVATE_KEY` credentials `release.yml` already depends on, so no new secrets are needed. The app needs `contents: write`.

## Behaviour worth knowing

- The workflow runs on every push to `main`. When the version is unchanged, it exits after the `ls-remote` check — a few seconds, no side effects.
- An existing tag is never overwritten, so re-running on an already-released version is a no-op. `workflow_dispatch` is enabled for manual re-runs.
- With this merged, the version bump PR *is* the release gate: whatever version reaches `main` gets tagged and published. A typo in `package.json` becomes a release, so the bump diff is the place to catch it.

## Testing

`eslint` passes and the workflow YAML parses. The end-to-end path — merge → tag → release — is exercised for real by merging this PR, which should produce the v1.8.0 release.

---
_Generated by [Claude Code](https://claude.ai/code/session_019XrbZaTCikv2agPfmfvCdQ)_