### PR TITLE
docs: add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## What
+
+<!-- What changes, and why. Prose, not a bullet dump. -->
+
+## Design & UX
+
+<!-- User-facing changes only: the decisions taken and the alternatives
+     rejected. Reference the Eight Golden Rules where they applied. -->
+
+## Details
+
+<!-- Migration and persistence, prompt changes, new network targets (CSP),
+     anything a reviewer would otherwise have to reconstruct from the diff. -->
+
+## Testing
+
+<!-- What was actually run, and what was not. -->
+
+---
+
+- [ ] New strings added to all four languages (en, de, es, fr)
+- [ ] New panels are collapsible, state persisted to localStorage
+- [ ] `npm run lint` and `npm run build` pass
+- [ ] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — or deliberately not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,10 @@ The code will be carefully reviewed by an expert for correctness, security, edge
 - Add new keys to all language objects (English, German, Spanish, French) in `translations.ts`
 - Update component to use `t.yourNewKey` pattern
 - All LLM-generated content (recipes, ingredients) will be translated via prompt instructions
+
+### When Opening a Pull Request
+
+Structure the description after `.github/pull_request_template.md` and work
+through its checklist. Creating a pull request through the API does not fill the
+template in — copy it across yourself. Replace the comments rather than leaving
+them in the body, and drop a section that has nothing to say.


### PR DESCRIPTION
## What

Adds `.github/pull_request_template.md` and an AGENTS.md section pointing at it.

Every session searched for a template, found nothing, and reinvented the structure from scratch. The searching itself is cheap — one or two tool calls; the cost is that the answer is always "no template", so each pull request starts from a blank page.

## Design & UX

**The template records the existing shape rather than imposing a new one.** The recent pull requests (#270, #272, #273, #275, #276) had already converged on what changed → the design reasoning → the details a reviewer cannot reconstruct from the diff → what was actually tested. A generic checkbox-heavy template would have been a regression here, so the four prose sections are the template and the checklist is a short appendix.

**The checklist only covers what is easy to forget and specific to this repo**: all four languages, collapsible panels with persisted state, lint and build, and the version bump. Since `tag-release.yml` derives the tag from `package.json`, the bump is now the release gate — that belongs in front of the reviewer, not in someone's memory.

**Comments are kept short** because a body still carrying its `<!-- -->` scaffolding reads as sloppy, and the shorter they are the smaller that failure mode is.

## Details

A template is **not** applied to pull requests created through the API — GitHub only pre-fills the web UI's compose form. So the file cannot enforce anything on agent-authored pull requests; its value is being findable at the path everyone already looks in. The AGENTS.md section says this explicitly and instructs copying the structure across by hand.

Written in English to match the rest of the repository's documentation, commit messages and pull request bodies.

Dependabot pull requests are unaffected — bot-authored bodies never pick up the template.

## Testing

`npm run lint` and `npm run build` pass. This pull request's own description is written from the template, which is the only real test a documentation change of this kind has.

---

- [x] New strings added to all four languages (en, de, es, fr) — n/a, no user-facing strings
- [x] New panels are collapsible, state persisted to localStorage — n/a, no UI change
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — deliberately not; documentation only, and a bump would trigger a release with no shipped change

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJVqmYJjgvWw4j3aYBmgZx)_