### PR TITLE
fix(a11y): colour contrast, dark-mode borders and html lang

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.9.1
+**Current version**: 1.9.2
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.9.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -74,7 +74,7 @@ export class ErrorBoundary extends Component<Props, State> {
                         )}
                         <button
                             onClick={this.handleReset}
-                            className="inline-flex items-center gap-2 bg-primary text-white px-6 py-3 rounded-full font-medium hover:bg-primary/90 transition-colors"
+                            className="inline-flex items-center gap-2 bg-primary text-text-on-primary px-6 py-3 rounded-full font-medium hover:bg-primary/90 transition-colors"
                         >
                             <RefreshCw size={18} />
                             Try Again

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -196,7 +196,7 @@ export const Header: React.FC<HeaderProps> = ({
             <div className="app-container flex flex-col items-start md:items-center py-1">
                 <div className="flex flex-col items-start gap-3 relative w-max ml-12 md:ml-0">
                     {/* Floating Leading Icon */}
-                    <div className={`absolute -left-16 top-0.5 p-2 bg-primary rounded-xl text-white shadow-lg shadow-primary/30 transition-all duration-300 scale-75 ${headerMinimized ? '' : 'md:scale-100'}`}>
+                    <div className={`absolute -left-16 top-0.5 p-2 bg-primary rounded-xl text-text-on-primary shadow-lg shadow-primary/30 transition-all duration-300 scale-75 ${headerMinimized ? '' : 'md:scale-100'}`}>
                         <Utensils className={`transition-all duration-300 w-5 h-5 ${headerMinimized ? '' : 'md:w-7 md:h-7'}`} />
                     </div>
 

--- a/src/components/RecipeChat.tsx
+++ b/src/components/RecipeChat.tsx
@@ -111,7 +111,7 @@ export const RecipeChat: React.FC<RecipeChatProps> = ({ recipe, chat }) => {
                         exit={{ opacity: 0, scale: 0.8 }}
                         onClick={() => setIsOpen(true)}
                         aria-label={t.recipeChat.open}
-                        className={`fixed left-4 z-40 h-14 w-14 rounded-full bg-primary text-white shadow-lg hover:bg-primary-hover transition-colors flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${STACK_ABOVE_TRAY}`}
+                        className={`fixed left-4 z-40 h-14 w-14 rounded-full bg-primary text-text-on-primary shadow-lg hover:bg-primary-hover transition-colors flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${STACK_ABOVE_TRAY}`}
                     >
                         <MessageCircle size={24} />
                         {messages.length > 0 && (
@@ -273,7 +273,7 @@ export const RecipeChat: React.FC<RecipeChatProps> = ({ recipe, chat }) => {
                                     onClick={() => ask(input)}
                                     disabled={isPending || !input.trim()}
                                     aria-label={t.recipeChat.send}
-                                    className="p-2 rounded-full bg-primary text-white hover:bg-primary-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+                                    className="p-2 rounded-full bg-primary text-text-on-primary hover:bg-primary-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
                                 >
                                     <Send size={16} />
                                 </button>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -143,7 +143,7 @@ export const SettingsPanel = forwardRef<SettingsPanelRef, SettingsPanelProps>(({
                                 />
                                 <button
                                     type="submit"
-                                    className="w-8 h-8 flex items-center justify-center rounded bg-primary hover:bg-primary-dark text-white shadow-sm transition-colors shrink-0"
+                                    className="w-8 h-8 flex items-center justify-center rounded bg-primary hover:bg-primary-hover text-text-on-primary shadow-sm transition-colors shrink-0"
                                     aria-label={t.add}
                                 >
                                     <Plus size={18} />
@@ -193,7 +193,7 @@ export const SettingsPanel = forwardRef<SettingsPanelRef, SettingsPanelProps>(({
                                 />
                                 <button
                                     type="submit"
-                                    className="w-8 h-8 flex items-center justify-center rounded bg-primary hover:bg-primary-dark text-white shadow-sm transition-colors shrink-0"
+                                    className="w-8 h-8 flex items-center justify-center rounded bg-primary hover:bg-primary-hover text-text-on-primary shadow-sm transition-colors shrink-0"
                                     aria-label={t.add}
                                 >
                                     <Plus size={18} />

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -285,7 +285,7 @@ export const SettingsPanel = forwardRef<SettingsPanelRef, SettingsPanelProps>(({
                 {loading ? (
                     <>
                         <span
-                            className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"
+                            className="animate-spin rounded-full h-5 w-5 border-b-2 border-current"
                             role="status"
                             aria-label={t.planning}
                         ></span>

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, type ReactNode } from 'react';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { translations } from '../constants/translations';
 import { STORAGE_KEYS, DEFAULTS } from '../constants';
@@ -16,6 +16,17 @@ const BROWSER_LANGUAGE_MAP: Record<string, SupportedLanguage> = {
     'de': 'German',
     'fr': 'French',
     'es': 'Spanish',
+};
+
+/**
+ * BCP-47 tag per supported language, mirrored onto <html lang>. Without it
+ * screen readers announce every translation with English pronunciation.
+ */
+const LANGUAGE_TAGS: Record<SupportedLanguage, string> = {
+    English: 'en',
+    German: 'de',
+    French: 'fr',
+    Spanish: 'es',
 };
 
 /**
@@ -145,6 +156,13 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
         if (key !== apiKey && imageGenEnabled) setImageGenEnabled(false);
         setApiKeyRaw(key);
     }, [apiKey, setApiKeyRaw, imageGenEnabled, setImageGenEnabled]);
+
+    // Mirror the UI language onto <html lang> so assistive technology switches
+    // pronunciation along with the interface.
+    useEffect(() => {
+        document.documentElement.lang =
+            LANGUAGE_TAGS[isValidLanguage(language) ? language : DEFAULTS.LANGUAGE];
+    }, [language]);
 
     const storagePersistError = useCopyPasteError || apiKeyError || peopleError || mealsError || dietError || styleWishesError || plannedRecipesError || languageError || imageGenEnabledError;
 

--- a/src/index.css
+++ b/src/index.css
@@ -62,7 +62,7 @@
   --color-text-light: hsl(var(--hue-neutral), 5%, 98%);
   --color-text-on-primary: hsl(0, 0%, 100%);
 
-  --color-border: hsl(var(--hue-neutral), 5%, 85%);
+  --color-border-base: hsl(var(--hue-neutral), 5%, 85%);
   --color-border-hover: hsl(var(--hue-neutral), 5%, 70%);
 
   /* Brand Colors */
@@ -95,7 +95,7 @@
        than the white used in light mode. */
     --color-text-on-primary: hsl(var(--hue-neutral), 5%, 10%);
 
-    --color-border: hsl(var(--hue-neutral), 5%, 20%);
+    --color-border-base: hsl(var(--hue-neutral), 5%, 20%);
     --color-border-hover: hsl(var(--hue-neutral), 5%, 30%);
 
     --color-primary: hsl(var(--hue-primary), 50%, 50%);

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,13 @@
 @import "tailwindcss";
 
 @theme {
-  /* Branding Colors - these reference :root CSS variables for dynamic theming */
-  --color-primary: hsl(155, 50%, 45%);
-  --color-primary-hover: hsl(155, 50%, 35%);
+  /* Branding Colors. These declarations exist so Tailwind emits the matching
+     utilities (bg-primary, text-primary, …); the values are light-mode
+     fallbacks. @theme lands in `@layer theme`, so the unlayered :root block
+     below always wins and is what actually drives the theme — keep the two in
+     sync, and give every token used by a utility a :root counterpart. */
+  --color-primary: hsl(155, 50%, 34%);
+  --color-primary-hover: hsl(155, 50%, 24%);
   --color-primary-light: hsl(155, 50%, 92%);
   --color-secondary: hsl(205, 70%, 50%);
 
@@ -15,6 +19,9 @@
   --color-text-main: hsl(240, 5%, 10%);
   --color-text-muted: hsl(240, 4%, 45%);
   --color-text-light: hsl(240, 5%, 98%);
+  /* Foreground for anything sitting on a filled --color-primary surface.
+     Flips to near-black in dark mode, where primary is light. */
+  --color-text-on-primary: hsl(0, 0%, 100%);
 
   --color-border-base: hsl(240, 5%, 85%);
   --color-border-hover: hsl(240, 5%, 70%);
@@ -33,10 +40,14 @@
   /* Universal Design Palette Base Neutrals: Zinc-like (Cool Greys) */
   --hue-neutral: 240;
 
-  /* Primary: Emerald/Teal - Accessible & Fresh */
+  /* Primary: Emerald/Teal - Accessible & Fresh.
+     34% keeps white-on-primary at 4.7:1 (WCAG AA) — primary doubles as a fill
+     under white text and as a text colour on light surfaces, and both roles
+     improve together as it darkens. Hover must stay below it so the button
+     still reads as advancing on hover. */
   --hue-primary: 155;
   --sat-primary: 50%;
-  --lig-primary: 45%;
+  --lig-primary: 34%;
 
   /* Secondary: Sky/Blue */
   --hue-secondary: 205;
@@ -49,13 +60,14 @@
   --color-text-main: hsl(var(--hue-neutral), 5%, 10%);
   --color-text-muted: hsl(var(--hue-neutral), 4%, 45%);
   --color-text-light: hsl(var(--hue-neutral), 5%, 98%);
+  --color-text-on-primary: hsl(0, 0%, 100%);
 
   --color-border: hsl(var(--hue-neutral), 5%, 85%);
   --color-border-hover: hsl(var(--hue-neutral), 5%, 70%);
 
   /* Brand Colors */
   --color-primary: hsl(var(--hue-primary), var(--sat-primary), var(--lig-primary));
-  --color-primary-hover: hsl(var(--hue-primary), var(--sat-primary), 35%);
+  --color-primary-hover: hsl(var(--hue-primary), var(--sat-primary), 24%);
   --color-primary-light: hsl(var(--hue-primary), var(--sat-primary), 92%);
 
   --color-secondary: hsl(var(--hue-secondary), 70%, 50%);
@@ -78,6 +90,10 @@
 
     --color-text-main: hsl(var(--hue-neutral), 5%, 92%);
     --color-text-muted: hsl(var(--hue-neutral), 4%, 60%);
+    /* Dark mode keeps primary light so it stays legible as a text colour on
+       dark surfaces; filled primary therefore needs dark text (7.6:1) rather
+       than the white used in light mode. */
+    --color-text-on-primary: hsl(var(--hue-neutral), 5%, 10%);
 
     --color-border: hsl(var(--hue-neutral), 5%, 20%);
     --color-border-hover: hsl(var(--hue-neutral), 5%, 30%);
@@ -153,7 +169,7 @@ button {
   }
 
   .btn-primary {
-    @apply bg-primary text-white shadow-md hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed disabled:shadow-none;
+    @apply bg-primary text-text-on-primary shadow-md hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed disabled:shadow-none;
     box-shadow: 0 4px 6px -1px hsla(var(--hue-primary), 60%, 40%, 0.2);
   }
 


### PR DESCRIPTION
## What

Three fixes from a universal-design pass over the app, one per commit so any of
them can be reverted on its own.

The primary colour failed WCAG AA in both roles it plays. As a fill under white
text it sat at 2.85:1 in light mode and 2.32:1 in dark mode, against a 4.5:1
threshold — and that fill carries the app's main call to action. As a text
colour on light surfaces, used in 50 places, it failed at the same 2.85:1.

Separately, the border token never reached dark mode. `@theme` declared
`--color-border-base`, which is what the `border-border-base` utility resolves
to and what all 31 border usages render with, while `:root` and the dark-mode
block declared `--color-border` — a different name. The dark-mode value was
never read, and `var(--color-border)` was referenced nowhere in the codebase.

And `index.html` hardcoded `lang="en"` with nothing ever updating it, so three
of the four languages were announced with English pronunciation.

## Design & UX

Light mode darkens `--lig-primary` from 45% to 34%. Both roles improve together
as it darkens, so one change covers both (4.71:1 each). `--color-primary-hover`
had to move from 35% to 24% alongside it: left at 35% it would have been
*lighter* than the new base, making the button appear to recede on hover.
That would have inverted the feedback the hover state exists to give
(Golden Rule 3, informative feedback).

Dark mode can't take the same treatment. Primary must stay light there to
remain legible as a text colour on dark surfaces, so no single lightness
satisfies both roles — at 35% the fill reaches 4.48:1 but primary-as-text drops
to 3.75:1 and fails. Filled primary instead flips its foreground to near-black
through a new `--color-text-on-primary` token, reaching 7.63:1 and leaving all
50 text usages untouched.

The dark-mode border bug had a visible cost: borders stayed at the light-mode
`hsl(240 5% 85%)`, rendering near-white at roughly 10:1 against the dark
surface. Users who choose dark mode to reduce glare got glaring outlines on
every panel, card and input. `--color-border-hover` was spelled correctly in
both blocks and *did* switch, so borders went darker on hover in dark mode —
inverted feedback again.

34% was chosen over 32% to stay closer to the existing brand green. The one
spot it doesn't fully cover is primary-as-text sitting directly on the app
background rather than on a panel, which lands at 4.29:1 — AA for large text
and UI components, 0.21 short for normal-size body text. In practice content
sits on `.glass-panel` or `.glass-card`, both lighter than the app background,
so this is an edge case rather than a live failure.

## Details

`--color-text-on-primary` is declared in `@theme` (so Tailwind emits the
`text-text-on-primary` utility), in `:root` as white, and in the dark-mode
block as near-black. Seven call sites move from `text-white` to the token:
`.btn-primary` plus the chat launcher, chat send button, header logo badge,
error-boundary button and the two settings steppers.

Those steppers also carried `hover:bg-primary-dark`. That token was never
defined anywhere, so Tailwind emitted no rule for it and the buttons had no
hover feedback at all — a pre-existing bug that surfaced while tracing the
colour tokens. They now use `primary-hover`.

The comment above `@theme` claimed its values "reference :root CSS variables".
They don't — they're literals, and `@theme` lands in `@layer theme` while the
`:root` block below is unlayered, so `:root` always wins. The comment now
describes the actual mechanism, since that mismatch is what let the border
token drift apart unnoticed.

The `lang` sync uses a BCP-47 lookup keyed by supported language, falling back
to the default for values that fail validation — localStorage is user-editable.

No new strings, no new panels, no CSP or prompt changes.

## Testing

`npm run lint`, `tsc -b` and `npm run build` all pass.

Contrast ratios were computed directly from the resulting HSL values rather
than eyeballed, and the built CSS was inspected to confirm the tokens resolve
as intended — specifically that `--color-border-base` is now overridden in the
dark-mode block and that `.btn-primary` compiles to
`color: var(--color-text-on-primary)`.

Rendered light and dark mode in headless Chromium and checked both
screenshots: dark mode no longer shows the light-grey outlines, and filled
primary buttons carry dark glyphs. The language switch was driven in the
browser and `document.documentElement.lang` confirmed to go from `en` to `de`.

Not tested: no actual screen-reader run, and no manual check of the hover
states at the new lightness values.

---

- [x] New strings added to all four languages (en, de, es, fr) — n/a, no new strings
- [x] New panels are collapsible, state persisted to localStorage — n/a, no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.9.2

---
_Generated by [Claude Code](https://claude.ai/code/session_0178TSEdfhz4h4fmDKgNjnvG)_