### PR TITLE
fix(a11y): make the warning colour a semantic token that passes AA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.9.2
+**Current version**: 1.9.3
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.9.2",
+  "version": "1.9.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ApiKeySecurityDialog.tsx
+++ b/src/components/ApiKeySecurityDialog.tsx
@@ -27,8 +27,8 @@ export const ApiKeySecurityDialog = ({
                 className="glass-panel w-full max-w-md p-6 shadow-2xl animate-in zoom-in-95 duration-200 outline-none"
             >
                 <div className="flex items-center gap-3 mb-4">
-                    <div className="p-2 bg-amber-500/20 rounded-xl">
-                        <ShieldAlert className="text-amber-500" size={24} />
+                    <div className="p-2 bg-warning/20 rounded-xl">
+                        <ShieldAlert className="text-warning-text" size={24} />
                     </div>
                     <h2 id="security-dialog-title" className="text-lg font-bold text-text-main">
                         {t.apiKeySecurity.title}
@@ -39,25 +39,25 @@ export const ApiKeySecurityDialog = ({
                     {t.apiKeySecurity.description}
                 </p>
 
-                <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4 mb-4">
-                    <p className="text-sm font-medium text-amber-700 dark:text-amber-400 mb-2">
+                <div className="bg-warning/10 border border-warning/30 rounded-lg p-4 mb-4">
+                    <p className="text-sm font-medium text-warning-text mb-2">
                         {t.apiKeySecurity.risks}
                     </p>
                     <ul className="space-y-2 text-sm text-text-muted">
                         <li className="flex items-start gap-2">
-                            <AlertTriangle className="text-amber-500 shrink-0 mt-0.5" size={14} />
+                            <AlertTriangle className="text-warning-text shrink-0 mt-0.5" size={14} />
                             <span>{t.apiKeySecurity.risk1}</span>
                         </li>
                         <li className="flex items-start gap-2">
-                            <AlertTriangle className="text-amber-500 shrink-0 mt-0.5" size={14} />
+                            <AlertTriangle className="text-warning-text shrink-0 mt-0.5" size={14} />
                             <span>{t.apiKeySecurity.risk2}</span>
                         </li>
                         <li className="flex items-start gap-2">
-                            <AlertTriangle className="text-amber-500 shrink-0 mt-0.5" size={14} />
+                            <AlertTriangle className="text-warning-text shrink-0 mt-0.5" size={14} />
                             <span>{t.apiKeySecurity.risk3}</span>
                         </li>
                         <li className="flex items-start gap-2">
-                            <AlertTriangle className="text-amber-500 shrink-0 mt-0.5" size={14} />
+                            <AlertTriangle className="text-warning-text shrink-0 mt-0.5" size={14} />
                             <span>{t.apiKeySecurity.risk4}</span>
                         </li>
                     </ul>
@@ -77,7 +77,7 @@ export const ApiKeySecurityDialog = ({
                     </button>
                     <button
                         onClick={onAccept}
-                        className="btn bg-amber-500 hover:bg-amber-600 text-white w-full py-3 rounded-xl shadow-lg"
+                        className="btn bg-warning hover:bg-warning-hover text-text-on-warning w-full py-3 rounded-xl shadow-lg"
                     >
                         {t.apiKeySecurity.understand}
                     </button>

--- a/src/components/GistSyncDialog.tsx
+++ b/src/components/GistSyncDialog.tsx
@@ -160,8 +160,8 @@ export const GistSyncDialog = ({
     const renderWarning = () => (
         <>
             <div className="flex items-center gap-3 mb-4">
-                <div className="p-2 bg-amber-500/20 rounded-xl">
-                    <ShieldAlert className="text-amber-500" size={24} />
+                <div className="p-2 bg-warning/20 rounded-xl">
+                    <ShieldAlert className="text-warning-text" size={24} />
                 </div>
                 <h2 id="sync-dialog-title" className="text-lg font-bold text-text-main">
                     {t.sync.securityTitle}
@@ -170,14 +170,14 @@ export const GistSyncDialog = ({
 
             <p className="text-text-base mb-4">{t.sync.securityDescription}</p>
 
-            <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4 mb-4">
-                <p className="text-sm font-medium text-amber-700 dark:text-amber-400 mb-2">
+            <div className="bg-warning/10 border border-warning/30 rounded-lg p-4 mb-4">
+                <p className="text-sm font-medium text-warning-text mb-2">
                     {t.sync.securityRisks}
                 </p>
                 <ul className="space-y-2 text-sm text-text-muted">
                     {[t.sync.securityRisk1, t.sync.securityRisk2, t.sync.securityRisk3, t.sync.securityRisk4].map((risk, i) => (
                         <li key={i} className="flex items-start gap-2">
-                            <AlertTriangle className="text-amber-500 shrink-0 mt-0.5" size={14} />
+                            <AlertTriangle className="text-warning-text shrink-0 mt-0.5" size={14} />
                             <span>{risk}</span>
                         </li>
                     ))}
@@ -190,7 +190,7 @@ export const GistSyncDialog = ({
                 <button
                     onClick={handleAcceptWarning}
                     autoFocus
-                    className="btn bg-amber-500 hover:bg-amber-600 text-white w-full py-3 rounded-xl shadow-lg"
+                    className="btn bg-warning hover:bg-warning-hover text-text-on-warning w-full py-3 rounded-xl shadow-lg"
                 >
                     {t.sync.securityAccept}
                 </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -48,7 +48,7 @@ export const Header: React.FC<HeaderProps> = ({
             case 'pushing':
                 return <Loader2 size={16} className="text-primary animate-spin" />;
             case 'pending':
-                return <Cloud size={16} className="text-amber-500" />;
+                return <Cloud size={16} className="text-warning-text" />;
             case 'synced':
                 return <Cloud size={16} className="text-primary" />;
             case 'error':

--- a/src/components/PhotoPrivacyDialog.tsx
+++ b/src/components/PhotoPrivacyDialog.tsx
@@ -36,7 +36,7 @@ export const PhotoPrivacyDialog = ({ onAccept, onCancel }: PhotoPrivacyDialogPro
                     {t.photoPrivacy.description}
                 </p>
 
-                <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4 mb-6">
+                <div className="bg-warning/10 border border-warning/30 rounded-lg p-4 mb-6">
                     <p className="text-sm text-text-muted">
                         {t.photoPrivacy.note}
                     </p>

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -240,7 +240,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
                     )}
                     {imageError && !imageUrl && !isImageLoading && (
                         <div className="w-full aspect-[4/3] flex flex-col items-center justify-center gap-3 text-text-muted p-6 text-center">
-                            <AlertCircle size={28} className="text-amber-500" />
+                            <AlertCircle size={28} className="text-warning-text" />
                             <span className="text-xs">{imageError}</span>
                             {onGenerateImage && (
                                 <button
@@ -303,16 +303,16 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
                 </section>
 
                 {recipe.missingIngredients && recipe.missingIngredients.length > 0 && (
-                    <section className="bg-amber-500/5 border border-amber-500/20 rounded-2xl p-4 animate-in fade-in slide-in-from-top-2">
+                    <section className="bg-warning/5 border border-warning/20 rounded-2xl p-4 animate-in fade-in slide-in-from-top-2">
                         <div className={`flex items-center justify-between ${!missingIngredientsMinimized ? 'mb-3' : ''}`}>
-                            <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+                            <div className="flex items-center gap-2 text-warning-text">
                                 <AlertCircle size={18} />
                                 <h4 className="font-bold uppercase tracking-wider text-xs">{t.needToBuy}</h4>
                             </div>
                             {onToggleMissingIngredientsMinimize && (
                                 <button
                                     onClick={onToggleMissingIngredientsMinimize}
-                                    className="p-2 bg-white/50 hover:bg-white/80 dark:bg-black/20 dark:hover:bg-black/40 rounded-full transition-colors text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 flex items-center justify-center"
+                                    className="p-2 bg-white/50 hover:bg-white/80 dark:bg-black/20 dark:hover:bg-black/40 rounded-full transition-colors text-warning-text flex items-center justify-center"
                                     aria-label={missingIngredientsMinimized ? 'Expand' : 'Collapse'}
                                     aria-expanded={!missingIngredientsMinimized}
                                 >
@@ -323,7 +323,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
                         {!missingIngredientsMinimized && (
                             <div className="flex flex-wrap gap-2">
                                 {recipe.missingIngredients.map((ing, idx) => (
-                                    <span key={`missing-${ing.item}-${ing.amount}-${idx}`} className="bg-amber-500/10 text-amber-700 dark:text-amber-300 px-3 py-1 rounded-full text-xs font-semibold border border-amber-500/10">
+                                    <span key={`missing-${ing.item}-${ing.amount}-${idx}`} className="bg-warning/10 text-warning-text px-3 py-1 rounded-full text-xs font-semibold border border-warning/10">
                                         {ing.amount} {ing.item}
                                     </span>
                                 ))}

--- a/src/components/TimerChip.tsx
+++ b/src/components/TimerChip.tsx
@@ -66,7 +66,7 @@ export const TimerChip: React.FC<TimerChipProps> = ({ sourceId, text, durationMs
   // Amber marks the extra time of a range as well as the finished timer; only
   // the finished one pulses. Pausing keeps the tone and adds the dashed border.
   const tone = done || followUp
-    ? 'bg-amber-500/15 text-amber-600 dark:text-amber-400 border-amber-500/30 hover:bg-amber-500/25'
+    ? 'bg-warning/15 text-warning-text border-warning/30 hover:bg-warning/25'
     : paused
       ? 'bg-secondary/5 text-secondary/60 border-secondary/30 hover:bg-secondary/15'
       : running

--- a/src/components/TimerTray.tsx
+++ b/src/components/TimerTray.tsx
@@ -89,20 +89,20 @@ export const TimerTray: React.FC = () => {
                       exit={{ opacity: 0, height: 0 }}
                       className={`flex items-center gap-2 rounded-lg border p-2 overflow-hidden ${
                         amber
-                          ? `bg-amber-500/10 border-amber-500/30 ${isDone ? 'animate-pulse' : ''}`
+                          ? `bg-warning/10 border-warning/30 ${isDone ? 'animate-pulse' : ''}`
                           : 'bg-white/40 dark:bg-black/20 border-border-base/30'
                       }`}
                     >
                       <div className="flex-1 min-w-0">
                         <p className="text-xs text-text-muted line-clamp-2" title={timer.label}>{timer.label}</p>
                         {isFollowUp && !isDone && (
-                          <p className="text-[0.65rem] font-bold uppercase tracking-wider text-amber-600 dark:text-amber-400" role="status">
+                          <p className="text-[0.65rem] font-bold uppercase tracking-wider text-warning-text" role="status">
                             {t.timers.followUp}
                           </p>
                         )}
                         <p
                           className={`font-mono tabular-nums text-sm font-semibold ${
-                            amber ? 'text-amber-600 dark:text-amber-400' : 'text-text-main'
+                            amber ? 'text-warning-text' : 'text-text-main'
                           }`}
                           role={isDone ? 'status' : undefined}
                         >

--- a/src/components/WelcomeDialog.tsx
+++ b/src/components/WelcomeDialog.tsx
@@ -82,7 +82,7 @@ export const WelcomeDialog: React.FC<WelcomeDialogProps> = ({ onClose }) => {
                     <div className="h-px bg-gradient-to-r from-transparent via-[var(--glass-border)] to-transparent my-4" />
 
                     <div className="flex gap-3">
-                        <HardDrive className="text-amber-500 shrink-0 mt-0.5" size={20} />
+                        <HardDrive className="text-warning-text shrink-0 mt-0.5" size={20} />
                         <p className="text-sm text-text-muted">{t.welcome.localStorage}</p>
                     </div>
                 </div>

--- a/src/components/ui/UndoToast.tsx
+++ b/src/components/ui/UndoToast.tsx
@@ -33,7 +33,7 @@ export const UndoToast = ({ notification }: UndoToastProps) => (
         className={`p-4 rounded-xl border text-sm animate-in fade-in slide-in-from-top-2 flex items-center justify-between gap-3 ${
             notification.type === 'error'
                 ? 'bg-red-50 text-red-600 border-red-100 dark:bg-red-950/50 dark:text-red-400 dark:border-red-900'
-                : 'bg-amber-50 text-amber-800 border-amber-200 dark:bg-amber-950/50 dark:text-amber-300 dark:border-amber-800'
+                : 'bg-warning/10 text-warning-text border-warning/30'
         }`}
     >
         <span className="flex-1">{renderTextWithLinks(notification.message)}</span>
@@ -44,7 +44,7 @@ export const UndoToast = ({ notification }: UndoToastProps) => (
                 className={`px-3 py-1 rounded-lg font-medium text-sm transition-colors shrink-0 ${
                     notification.type === 'error'
                         ? 'bg-red-100 hover:bg-red-200 dark:bg-red-900 dark:hover:bg-red-800'
-                        : 'bg-amber-200 hover:bg-amber-300 dark:bg-amber-800 dark:hover:bg-amber-700'
+                        : 'bg-warning/20 hover:bg-warning/30'
                 }`}
             >
                 {notification.action.label}

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,15 @@
      Flips to near-black in dark mode, where primary is light. */
   --color-text-on-primary: hsl(0, 0%, 100%);
 
+  /* Warning (amber). Split into a fill role and a text role: the fill stays
+     bright so it still reads as a warning, which forces dark text on top of
+     it, while amber used *as* text or as a meaningful icon has to be dark
+     enough on its own. One value cannot serve both. */
+  --color-warning: hsl(38, 92%, 50%);
+  --color-warning-hover: hsl(38, 92%, 43%);
+  --color-warning-text: hsl(28, 90%, 31%);
+  --color-text-on-warning: hsl(240, 5%, 10%);
+
   --color-border-base: hsl(240, 5%, 85%);
   --color-border-hover: hsl(240, 5%, 70%);
 
@@ -52,6 +61,14 @@
   /* Secondary: Sky/Blue */
   --hue-secondary: 205;
 
+  /* Warning: Amber. 50% is the familiar warning yellow; it is far too light to
+     carry white text (2.1:1), so --color-text-on-warning is near-black in both
+     themes (8.3:1) rather than the fill being darkened into a muddy orange.
+     --color-warning-text is the same hue several rungs down, dark enough to
+     clear 4.5:1 as text and as an icon on every surface it lands on, including
+     the amber tints. */
+  --hue-warning: 38;
+
   /* Light Mode Semantic Colors */
   --color-bg-app: hsl(var(--hue-neutral), 5%, 96%);
   --color-bg-surface: hsl(255, 100%, 100%);
@@ -61,6 +78,7 @@
   --color-text-muted: hsl(var(--hue-neutral), 4%, 45%);
   --color-text-light: hsl(var(--hue-neutral), 5%, 98%);
   --color-text-on-primary: hsl(0, 0%, 100%);
+  --color-text-on-warning: hsl(var(--hue-neutral), 5%, 10%);
 
   --color-border-base: hsl(var(--hue-neutral), 5%, 85%);
   --color-border-hover: hsl(var(--hue-neutral), 5%, 70%);
@@ -71,6 +89,10 @@
   --color-primary-light: hsl(var(--hue-primary), var(--sat-primary), 92%);
 
   --color-secondary: hsl(var(--hue-secondary), 70%, 50%);
+
+  --color-warning: hsl(var(--hue-warning), 92%, 50%);
+  --color-warning-hover: hsl(var(--hue-warning), 92%, 43%);
+  --color-warning-text: hsl(28, 90%, 31%);
 
   /* Glass Effects */
   --glass-bg: hsla(0, 0%, 100%, 0.7);
@@ -101,6 +123,13 @@
     --color-primary: hsl(var(--hue-primary), 50%, 50%);
     --color-primary-hover: hsl(var(--hue-primary), 50%, 60%);
     --color-primary-light: hsl(var(--hue-primary), 50%, 15%);
+
+    /* The fill and its dark foreground carry over unchanged — amber is light
+       enough that both roles already clear AA on a dark surface. Only the
+       hover flips direction (lighter, so the button still advances) and the
+       text rung moves up the scale to stay legible on dark. */
+    --color-warning-hover: hsl(var(--hue-warning), 92%, 58%);
+    --color-warning-text: hsl(43, 96%, 56%);
 
     --glass-bg: hsla(var(--hue-neutral), 5%, 12%, 0.6);
     --glass-border: hsla(var(--hue-neutral), 5%, 80%, 0.08);


### PR DESCRIPTION
## What

Amber was the last colour in the app spread across components as raw Tailwind
utilities — 59 occurrences across 9 files, with no central lever — and its
light-mode pairings failed WCAG AA. White on `amber-500` measured 2.15:1 (worse
than the primary button before #279), the `amber-600` hover only reached 3.19:1,
`amber-600` as text on a white surface 3.19:1, and `amber-500` icons 2.15:1
against the 3:1 threshold for meaningful non-text content. Dark mode was fine
throughout.

This fixes the contrast and gives the warning colour semantic tokens in the same
move, so it can be steered from `src/index.css` afterwards rather than from
eleven components.

## Design & UX

Amber is a light hue, so a filled amber surface wants *dark* text — the same
conclusion #279 reached for dark-mode primary. Darkening the fill to `amber-700`
would also have passed with white text (5.05:1), but it turns the button into a
brownish dark orange and loses the warning character, so dark-on-amber is the
better trade. The filled warning buttons keep their familiar amber and take
near-black labels.

Amber has a second, conflicting role: used *as* text or as a meaningful icon on
a surface, it has to be dark enough on its own. One value cannot serve both, so
fill and text are split:

| token | light | dark |
|---|---|---|
| `--color-warning` | `hsl(38, 92%, 50%)` | unchanged |
| `--color-warning-hover` | `hsl(38, 92%, 43%)` | `hsl(38, 92%, 58%)` |
| `--color-text-on-warning` | `hsl(240, 5%, 10%)` | unchanged |
| `--color-warning-text` | `hsl(28, 90%, 31%)` | `hsl(43, 96%, 56%)` |

Icons fold into the text role rather than getting a third token: at 4.5:1+ they
clear the 3:1 icon threshold comfortably, and a warning box whose icon and
heading are the same colour reads as one object (Golden Rule 1 — consistency).
Previously the icon was `amber-500` and the heading beside it `amber-700`.

Hover keeps its direction in each theme: darker than the fill in light mode,
lighter in dark, so a warning button never appears to recede on hover (Golden
Rule 3 — informative feedback).

`UndoToast`'s amber variant moved onto the same tokens too. It was on a
different rung of the scale (`amber-50/200/800/950`) and already passed
contrast, but leaving it behind would have meant amber was still not steerable
from one place. It now matches the other warning surfaces exactly.

## Details

Each token is declared in `@theme` (so Tailwind emits `bg-warning`,
`text-warning-text`, …), in `:root`, and — where it differs — in the dark-mode
block. Watch this if you touch it: `@theme` lands in `@layer theme` while
`:root` is unlayered, so a token declared in one place under a name that does
not exist in the other silently never switches themes. That trap is what #279
uncovered; all four tokens here are declared in both.

`--color-warning` and `--color-text-on-warning` are deliberately identical in
both themes. Amber is light enough that the fill still carries near-black text
on a dark surface, and bright enough as an icon there (7.8:1), so only the hover
direction and the text rung need to flip.

All 30 amber call sites are converted; no `dark:` variants remain on them, since
the tokens are theme-aware. The tint and border alphas (`bg-warning/10`,
`border-warning/30`, …) carry over unchanged from their `amber-500/x`
equivalents — `--color-warning` is the same colour `amber-500` was.

## Testing

`npm run lint` and `npm run build` pass.

Contrast was computed against the resulting token values (not the Tailwind
palette, and not estimated), including the composited backgrounds — the
translucent glass panel over the app background, each amber tint over that
panel, and the `UndoToast` button's tint layered over the toast's own tint.
30 pairings checked across both themes, all passing:

| role | worst case | plain surface |
|---|---|---|
| `text-on-warning` on the fill | 8.31:1 | hover 6.20 light / 9.29 dark |
| `warning-text` on light surfaces | 4.75:1 (darkest tint) | 6.40 |
| `warning-text` on dark surfaces | 4.77:1 (darkest tint) | 9.93 |
| `text-muted` inside a warning tint | 4.58:1 light / 5.02:1 dark | — |

The built CSS was checked to confirm every utility resolves through `var()` and
that the dark-mode block overrides land. Both themes were rendered from the
production stylesheet and inspected visually.

Not run: no automated visual regression or axe pass exists in this repo.

---

- [x] New strings added to all four languages (en, de, es, fr) — no new strings
- [x] New panels are collapsible, state persisted to localStorage — no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.9.3

Closes #280

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bh3TtxHHmzyEjgWyJL1RV7)_