### PR TITLE
fix(a11y): give the warning button its own fill so it stops outshouting primary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.9.3
+**Current version**: 1.9.4
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.9.3",
+      "version": "1.9.4",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.9.3",
+  "version": "1.9.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ApiKeySecurityDialog.tsx
+++ b/src/components/ApiKeySecurityDialog.tsx
@@ -77,7 +77,7 @@ export const ApiKeySecurityDialog = ({
                     </button>
                     <button
                         onClick={onAccept}
-                        className="btn bg-warning hover:bg-warning-hover text-text-on-warning w-full py-3 rounded-xl shadow-lg"
+                        className="btn bg-warning-fill hover:bg-warning-fill-hover text-text-on-warning w-full py-3 rounded-xl shadow-lg"
                     >
                         {t.apiKeySecurity.understand}
                     </button>

--- a/src/components/GistSyncDialog.tsx
+++ b/src/components/GistSyncDialog.tsx
@@ -190,7 +190,7 @@ export const GistSyncDialog = ({
                 <button
                     onClick={handleAcceptWarning}
                     autoFocus
-                    className="btn bg-warning hover:bg-warning-hover text-text-on-warning w-full py-3 rounded-xl shadow-lg"
+                    className="btn bg-warning-fill hover:bg-warning-fill-hover text-text-on-warning w-full py-3 rounded-xl shadow-lg"
                 >
                     {t.sync.securityAccept}
                 </button>

--- a/src/index.css
+++ b/src/index.css
@@ -23,14 +23,14 @@
      Flips to near-black in dark mode, where primary is light. */
   --color-text-on-primary: hsl(0, 0%, 100%);
 
-  /* Warning (amber). Split into a fill role and a text role: the fill stays
-     bright so it still reads as a warning, which forces dark text on top of
-     it, while amber used *as* text or as a meaningful icon has to be dark
-     enough on its own. One value cannot serve both. */
+  /* Warning (amber), three roles that cannot share one value: the accent that
+     tints surfaces and borders, the solid fill under a button label, and amber
+     used as text or as a meaningful icon on a surface. */
   --color-warning: hsl(38, 92%, 50%);
-  --color-warning-hover: hsl(38, 92%, 43%);
+  --color-warning-fill: hsl(30, 92%, 36%);
+  --color-warning-fill-hover: hsl(30, 92%, 30%);
   --color-warning-text: hsl(28, 90%, 31%);
-  --color-text-on-warning: hsl(240, 5%, 10%);
+  --color-text-on-warning: hsl(0, 0%, 100%);
 
   --color-border-base: hsl(240, 5%, 85%);
   --color-border-hover: hsl(240, 5%, 70%);
@@ -61,12 +61,15 @@
   /* Secondary: Sky/Blue */
   --hue-secondary: 205;
 
-  /* Warning: Amber. 50% is the familiar warning yellow; it is far too light to
-     carry white text (2.1:1), so --color-text-on-warning is near-black in both
-     themes (8.3:1) rather than the fill being darkened into a muddy orange.
-     --color-warning-text is the same hue several rungs down, dark enough to
-     clear 4.5:1 as text and as an icon on every surface it lands on, including
-     the amber tints. */
+  /* Warning: Amber. 50% is the familiar warning yellow and stays the accent
+     behind every tint and border. As a solid button fill it is another matter:
+     at that lightness it is 4.4x as bright as the primary button, so a warning
+     button outshouts the recommended one next to it whatever colour its label
+     is. --color-warning-fill therefore drops down the ramp in light mode until
+     it carries white like the primary does and weighs the same; in dark mode,
+     where primary is itself light, the fill stays at 50% and takes dark text.
+     --color-warning-text is a third rung again, dark enough to clear 4.5:1 as
+     text and as an icon on every surface it lands on, tints included. */
   --hue-warning: 38;
 
   /* Light Mode Semantic Colors */
@@ -78,7 +81,7 @@
   --color-text-muted: hsl(var(--hue-neutral), 4%, 45%);
   --color-text-light: hsl(var(--hue-neutral), 5%, 98%);
   --color-text-on-primary: hsl(0, 0%, 100%);
-  --color-text-on-warning: hsl(var(--hue-neutral), 5%, 10%);
+  --color-text-on-warning: hsl(0, 0%, 100%);
 
   --color-border-base: hsl(var(--hue-neutral), 5%, 85%);
   --color-border-hover: hsl(var(--hue-neutral), 5%, 70%);
@@ -91,7 +94,8 @@
   --color-secondary: hsl(var(--hue-secondary), 70%, 50%);
 
   --color-warning: hsl(var(--hue-warning), 92%, 50%);
-  --color-warning-hover: hsl(var(--hue-warning), 92%, 43%);
+  --color-warning-fill: hsl(30, 92%, 36%);
+  --color-warning-fill-hover: hsl(30, 92%, 30%);
   --color-warning-text: hsl(28, 90%, 31%);
 
   /* Glass Effects */
@@ -124,11 +128,14 @@
     --color-primary-hover: hsl(var(--hue-primary), 50%, 60%);
     --color-primary-light: hsl(var(--hue-primary), 50%, 15%);
 
-    /* The fill and its dark foreground carry over unchanged — amber is light
-       enough that both roles already clear AA on a dark surface. Only the
-       hover flips direction (lighter, so the button still advances) and the
-       text rung moves up the scale to stay legible on dark. */
-    --color-warning-hover: hsl(var(--hue-warning), 92%, 58%);
+    /* Dark mode needs no darkened fill: primary is light here too, so a warning
+       button at full amber weighs the same as the primary beside it instead of
+       outshouting it. The fill therefore returns to the accent value and takes
+       dark text, exactly as --color-text-on-primary does. Hover goes lighter so
+       the button still advances, and the text rung moves up to stay legible. */
+    --color-text-on-warning: hsl(var(--hue-neutral), 5%, 10%);
+    --color-warning-fill: hsl(var(--hue-warning), 92%, 50%);
+    --color-warning-fill-hover: hsl(var(--hue-warning), 92%, 58%);
     --color-warning-text: hsl(43, 96%, 56%);
 
     --glass-bg: hsla(var(--hue-neutral), 5%, 12%, 0.6);


### PR DESCRIPTION
## What

Follow-up to #287. That PR made the filled warning button carry near-black text,
which is correct for contrast but wrong for hierarchy: the primary button beside
it carries white, so the two labels read as two different kinds of control — and
in `ApiKeySecurityDialog` the amber button is the *discouraged* option while the
green one is recommended. The risky choice looked like the recommended one.

The label colour was only half the cause. At 50% lightness amber has a relative
luminance of 0.442 against the primary fill's 0.173 — **2.6× as bright**. It
draws the eye whatever colour its label is. Dropping it down the ramp far enough
to carry white text lands it at 0.169, essentially the primary's own weight, so
both problems resolve together: equal visual weight, and the same white label on
both buttons.

## Design & UX

The fill gets its own token rather than the accent being darkened, because
`--color-warning` also drives every tint and border in the app:

| token | light | dark |
|---|---|---|
| `--color-warning` (accent, tints, borders) | `hsl(38, 92%, 50%)` | unchanged |
| `--color-warning-fill` | `hsl(30, 92%, 36%)` | `hsl(38, 92%, 50%)` |
| `--color-warning-fill-hover` | `hsl(30, 92%, 30%)` | `hsl(38, 92%, 58%)` |
| `--color-text-on-warning` | white | near-black |
| `--color-warning-text` | unchanged | unchanged |

Darkening the shared accent instead would have cost the tints their signal. In
light mode the warning boxes turn from pale yellow `#fbf3e4` to tan `#f4ece4`;
in dark mode it is worse, where a 10% tint's separation from the panel falls
from 1.19:1 to 1.09:1 and the warning surfaces all but disappear.

Dark mode needs no darkened fill at all. Primary is light there too, so amber at
full strength already weighs the same as the button beside it and keeps its dark
label. `--color-warning-fill` therefore behaves exactly like `--color-primary` —
dark in light mode, light in dark mode — and `--color-text-on-warning` now
mirrors `--color-text-on-primary` in both themes.

The trade this accepts: `#b05c07` is a burnt orange rather than a warning
yellow. On a button flanked by a green one the context carries the meaning, and
the warning boxes above it keep the yellow — but it is a real change in
character, and the reverse of the call made in #280.

## Details

Two call sites change, both filled warning buttons:
`ApiKeySecurityDialog.tsx:80` and `GistSyncDialog.tsx:193`.

`--color-warning-hover` is replaced by `--color-warning-fill-hover`; it had no
other consumer, since the tints hover via alpha (`hover:bg-warning/25`) rather
than through a token. Icons, timer chips, the missing-ingredient chips and the
undo toast are untouched — they resolve through `--color-warning-text`, whose
values are unchanged and whose ratios were verified in #287.

## Testing

`npm run lint` and `npm run build` pass.

Contrast computed against the resulting token values, including the button
outline against the translucent glass panel over the app background:

| check | light | dark |
|---|---|---|
| label on the fill | 4.79:1 | 8.31:1 |
| label on the hover fill | 6.35:1 | 9.29:1 |
| fill against the panel (1.4.11, ≥3:1) | 4.67:1 | 8.31:1 |
| visual weight vs the primary button | 0.98× (was 2.56×) | 1.10× (unchanged) |

Hover keeps its direction in both themes — darker than the fill in light, lighter
in dark — so the button still reads as advancing.

The built CSS was checked to confirm all four tokens appear in `:root` and the
dark-mode block and that every utility resolves through `var()`. Both dialogs
were rendered from the production stylesheet in both themes and inspected.

Not run: no automated visual regression or axe pass exists in this repo.

## Follow-up

A second PR will address what this one exposed: green currently means both "the
safe choice" and "confirm", red sits on the two actions that *reduce* data
exposure, and the three consent dialogs order and label their buttons three
different ways. That work covers button roles, order, focus handling and copy in
four languages, and is deliberately kept out of this colour-only change.

---

- [x] New strings added to all four languages (en, de, es, fr) — no new strings
- [x] New panels are collapsible, state persisted to localStorage — no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.9.4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bh3TtxHHmzyEjgWyJL1RV7)_