### PR TITLE
feat(dialogs): let button colour and order say what each choice risks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.9.4
+**Current version**: 1.10.0
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.9.4",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.9.4",
+      "version": "1.10.0",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.9.4",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ApiKeySecurityDialog.tsx
+++ b/src/components/ApiKeySecurityDialog.tsx
@@ -4,15 +4,15 @@ import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface ApiKeySecurityDialogProps {
     onAccept: () => void;
-    onUseCopyPaste: () => void;
+    onCancel: () => void;
 }
 
 export const ApiKeySecurityDialog = ({
     onAccept,
-    onUseCopyPaste,
+    onCancel,
 }: ApiKeySecurityDialogProps) => {
     const { t } = useSettings();
-    const dialogRef = useFocusTrap(onUseCopyPaste);
+    const dialogRef = useFocusTrap(onCancel, true);
 
     return (
         <div
@@ -64,22 +64,21 @@ export const ApiKeySecurityDialog = ({
                 </div>
 
                 <p className="text-sm text-text-muted mb-6">
-                    {t.apiKeySecurity.recommendation}
+                    {t.apiKeySecurity.usage}
                 </p>
 
                 <div className="flex flex-col gap-3">
                     <button
-                        onClick={onUseCopyPaste}
-                        autoFocus
-                        className="btn btn-primary w-full py-3 rounded-xl shadow-lg shadow-primary/20"
-                    >
-                        {t.apiKeySecurity.useCopyPaste}
-                    </button>
-                    <button
                         onClick={onAccept}
-                        className="btn bg-warning-fill hover:bg-warning-fill-hover text-text-on-warning w-full py-3 rounded-xl shadow-lg"
+                        className="btn btn-warning w-full py-3 rounded-xl"
                     >
                         {t.apiKeySecurity.understand}
+                    </button>
+                    <button
+                        onClick={onCancel}
+                        className="btn btn-quiet w-full py-3 rounded-xl"
+                    >
+                        {t.apiKeySecurity.cancel}
                     </button>
                 </div>
             </div>

--- a/src/components/ClearApiKeyDialog.tsx
+++ b/src/components/ClearApiKeyDialog.tsx
@@ -1,4 +1,4 @@
-import { Key, Trash2 } from 'lucide-react';
+import { Key } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 
@@ -12,7 +12,7 @@ export const ClearApiKeyDialog = ({
     onKeep,
 }: ClearApiKeyDialogProps) => {
     const { t } = useSettings();
-    const dialogRef = useFocusTrap(onKeep);
+    const dialogRef = useFocusTrap(onKeep, true);
 
     return (
         <div
@@ -41,18 +41,16 @@ export const ClearApiKeyDialog = ({
 
                 <div className="flex flex-col gap-3">
                     <button
-                        onClick={onKeep}
-                        autoFocus
-                        className="btn bg-white/50 hover:bg-white/70 dark:bg-black/30 dark:hover:bg-black/40 text-text-main w-full py-3 rounded-xl border border-[var(--glass-border)]"
+                        onClick={onClear}
+                        className="btn btn-primary w-full py-3 rounded-xl"
                     >
-                        {t.clearApiKey.keep}
+                        {t.clearApiKey.clear}
                     </button>
                     <button
-                        onClick={onClear}
-                        className="btn bg-red-500 hover:bg-red-600 text-white w-full py-3 rounded-xl shadow-lg flex items-center justify-center gap-2"
+                        onClick={onKeep}
+                        className="btn btn-quiet w-full py-3 rounded-xl"
                     >
-                        <Trash2 size={18} />
-                        {t.clearApiKey.clear}
+                        {t.clearApiKey.keep}
                     </button>
                 </div>
             </div>

--- a/src/components/GistSyncDialog.tsx
+++ b/src/components/GistSyncDialog.tsx
@@ -192,7 +192,6 @@ export const GistSyncDialog = ({
             <div className="flex flex-col gap-3">
                 <button
                     onClick={handleAcceptWarning}
-                    autoFocus
                     className="btn btn-warning w-full py-3 rounded-xl"
                 >
                     {t.sync.securityAccept}

--- a/src/components/GistSyncDialog.tsx
+++ b/src/components/GistSyncDialog.tsx
@@ -44,7 +44,10 @@ export const GistSyncDialog = ({
     onShowInfo,
 }: GistSyncDialogProps) => {
     const { t } = useSettings();
-    const dialogRef = useFocusTrap(onClose);
+    // No button is a safe default in the warning and active steps. The setup
+    // step is unaffected: its token input carries autoFocus, and the trap
+    // leaves focus alone when something inside already holds it.
+    const dialogRef = useFocusTrap(onClose, true);
 
     const initiallyConfigured = readConfigured();
     const [step, setStep] = useState<Step>(() => {
@@ -190,13 +193,13 @@ export const GistSyncDialog = ({
                 <button
                     onClick={handleAcceptWarning}
                     autoFocus
-                    className="btn bg-warning-fill hover:bg-warning-fill-hover text-text-on-warning w-full py-3 rounded-xl shadow-lg"
+                    className="btn btn-warning w-full py-3 rounded-xl"
                 >
                     {t.sync.securityAccept}
                 </button>
                 <button
                     onClick={onClose}
-                    className="btn btn-primary w-full py-3 rounded-xl"
+                    className="btn btn-quiet w-full py-3 rounded-xl"
                 >
                     {t.sync.securityCancel}
                 </button>
@@ -269,21 +272,21 @@ export const GistSyncDialog = ({
                 <button
                     onClick={handleCreateNew}
                     disabled={busy}
-                    className="btn btn-primary w-full py-3 rounded-xl shadow-lg shadow-primary/20 disabled:opacity-60"
+                    className="btn btn-warning w-full py-3 rounded-xl"
                 >
                     {busy ? t.sync.creating : t.sync.createNew}
                 </button>
                 <button
                     onClick={handleUseExisting}
                     disabled={busy}
-                    className="btn bg-white/60 dark:bg-black/30 hover:bg-white/80 dark:hover:bg-black/40 text-text-main w-full py-3 rounded-xl border border-[var(--glass-border)] disabled:opacity-60"
+                    className="btn btn-warning w-full py-3 rounded-xl"
                 >
                     {busy ? t.sync.connecting : t.sync.useExisting}
                 </button>
                 <button
                     onClick={onClose}
                     disabled={busy}
-                    className="btn text-text-muted hover:text-text-main w-full py-2 rounded-xl"
+                    className="btn btn-quiet w-full py-2 rounded-xl"
                 >
                     {t.sync.close}
                 </button>
@@ -333,14 +336,13 @@ export const GistSyncDialog = ({
                 <div className="flex flex-col gap-3">
                     <button
                         onClick={handleDisable}
-                        className="btn bg-red-500 hover:bg-red-600 text-white w-full py-3 rounded-xl shadow-lg"
+                        className="btn btn-primary w-full py-3 rounded-xl"
                     >
                         {t.sync.disable}
                     </button>
                     <button
                         onClick={onClose}
-                        autoFocus
-                        className="btn btn-primary w-full py-3 rounded-xl"
+                        className="btn btn-quiet w-full py-3 rounded-xl"
                     >
                         {t.sync.close}
                     </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,6 +11,9 @@ import { buildExportData, downloadExportFile, readImportFile, applyImportData } 
 import type { Notification } from '../types';
 import type { SyncStatus } from '../hooks/useGistSync';
 
+const hasSeenApiKeyWarning = () =>
+    localStorage.getItem(STORAGE_KEYS.API_KEY_WARNING_SEEN) === 'true';
+
 interface HeaderProps {
     headerMinimized: boolean;
     setHeaderMinimized: (minimized: boolean) => void;
@@ -33,10 +36,9 @@ export const Header: React.FC<HeaderProps> = ({
     const { useCopyPaste, setUseCopyPaste, apiKey, setApiKey, language, setLanguage, imageGenEnabled, setImageGenEnabled, t } = useSettings();
 
     // Check on mount if existing user needs to see the security warning
-    const [showSecurityDialog, setShowSecurityDialog] = useState(() => {
-        const hasSeenWarning = localStorage.getItem(STORAGE_KEYS.API_KEY_WARNING_SEEN) === 'true';
-        return !hasSeenWarning && !!apiKey && !useCopyPaste;
-    });
+    const [showSecurityDialog, setShowSecurityDialog] = useState(
+        () => !hasSeenApiKeyWarning() && !!apiKey && !useCopyPaste
+    );
     const [showClearDialog, setShowClearDialog] = useState(false);
     const [showSyncDialog, setShowSyncDialog] = useState(false);
     const [pendingModeSwitch, setPendingModeSwitch] = useState<'toApiKey' | 'toCopyPaste' | null>(null);
@@ -132,7 +134,15 @@ export const Header: React.FC<HeaderProps> = ({
 
     const handleModeToggle = () => {
         if (useCopyPaste) {
-            // Switching TO API Key mode - always show warning
+            // Switching TO API Key mode. The warning is about a key being
+            // stored, so it only earns its place while none is: with a key
+            // already in local storage the switch exposes nothing new, and
+            // once the warning has been acknowledged the header's persistent
+            // apiKeyStoredWarning tooltip carries the reminder from there.
+            if (apiKey || hasSeenApiKeyWarning()) {
+                setUseCopyPaste(false);
+                return;
+            }
             setPendingModeSwitch('toApiKey');
             setShowSecurityDialog(true);
         } else {
@@ -164,7 +174,7 @@ export const Header: React.FC<HeaderProps> = ({
         setPendingModeSwitch(null);
     };
 
-    const handleSecurityUseCopyPaste = () => {
+    const handleSecurityCancel = () => {
         markApiKeyWarningSeen();
         setShowSecurityDialog(false);
 
@@ -401,7 +411,7 @@ export const Header: React.FC<HeaderProps> = ({
         {showSecurityDialog && (
             <ApiKeySecurityDialog
                 onAccept={handleSecurityAccept}
-                onUseCopyPaste={handleSecurityUseCopyPaste}
+                onCancel={handleSecurityCancel}
             />
         )}
 

--- a/src/components/PhotoPrivacyDialog.tsx
+++ b/src/components/PhotoPrivacyDialog.tsx
@@ -1,4 +1,4 @@
-import { Camera } from 'lucide-react';
+import { Camera, AlertTriangle } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 
@@ -9,7 +9,7 @@ interface PhotoPrivacyDialogProps {
 
 export const PhotoPrivacyDialog = ({ onAccept, onCancel }: PhotoPrivacyDialogProps) => {
     const { t } = useSettings();
-    const dialogRef = useFocusTrap(onCancel);
+    const dialogRef = useFocusTrap(onCancel, true);
 
     return (
         <div
@@ -24,8 +24,8 @@ export const PhotoPrivacyDialog = ({ onAccept, onCancel }: PhotoPrivacyDialogPro
                 className="glass-panel w-full max-w-md p-6 shadow-2xl animate-in zoom-in-95 duration-200 outline-none"
             >
                 <div className="flex items-center gap-3 mb-4">
-                    <div className="p-2 bg-primary/20 rounded-xl">
-                        <Camera className="text-primary" size={24} />
+                    <div className="p-2 bg-warning/20 rounded-xl">
+                        <Camera className="text-warning-text" size={24} />
                     </div>
                     <h2 id="photo-privacy-title" className="text-lg font-bold text-text-main">
                         {t.photoPrivacy.title}
@@ -36,23 +36,34 @@ export const PhotoPrivacyDialog = ({ onAccept, onCancel }: PhotoPrivacyDialogPro
                     {t.photoPrivacy.description}
                 </p>
 
-                <div className="bg-warning/10 border border-warning/30 rounded-lg p-4 mb-6">
-                    <p className="text-sm text-text-muted">
-                        {t.photoPrivacy.note}
+                <div className="bg-warning/10 border border-warning/30 rounded-lg p-4 mb-4">
+                    <p className="text-sm font-medium text-warning-text mb-2">
+                        {t.photoPrivacy.beforeYouSend}
                     </p>
+                    <ul className="space-y-2 text-sm text-text-muted">
+                        {[t.photoPrivacy.note1, t.photoPrivacy.note2].map((note) => (
+                            <li key={note} className="flex items-start gap-2">
+                                <AlertTriangle className="text-warning-text shrink-0 mt-0.5" size={14} />
+                                <span>{note}</span>
+                            </li>
+                        ))}
+                    </ul>
                 </div>
+
+                <p className="text-sm text-text-muted mb-6">
+                    {t.photoPrivacy.usage}
+                </p>
 
                 <div className="flex flex-col gap-3">
                     <button
                         onClick={onAccept}
-                        autoFocus
-                        className="btn btn-primary w-full py-3 rounded-xl shadow-lg shadow-primary/20"
+                        className="btn btn-warning w-full py-3 rounded-xl"
                     >
-                        {t.photoPrivacy.understand}
+                        {t.photoPrivacy.send}
                     </button>
                     <button
                         onClick={onCancel}
-                        className="btn bg-white/10 hover:bg-white/20 text-text-main w-full py-3 rounded-xl"
+                        className="btn btn-quiet w-full py-3 rounded-xl"
                     >
                         {t.photoPrivacy.cancel}
                     </button>

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -54,11 +54,14 @@ export const translations = {
             quotaExceeded: "Photo identification quota exceeded. Please try again later.",
         },
         photoPrivacy: {
-            title: "Identify ingredient from photo",
-            description: "Take or choose a photo of a single ingredient. The image is sent to Google Gemini, which returns the ingredient name.",
-            note: "The photo leaves your device. It is not stored by this app, but Google's terms apply.",
+            title: "Your photo will be sent to Google",
+            description: "To identify an ingredient, the picture is uploaded to Google Gemini, which returns the ingredient name.",
+            beforeYouSend: "Before you send:",
+            note1: "The photo leaves your device and is processed on Google's servers.",
+            note2: "Make sure no people, documents or anything else are in the frame.",
+            usage: "This app does not store the photo, but Google's terms and data handling apply.",
             cancel: "Cancel",
-            understand: "Continue",
+            send: "Send photo",
         },
         meals: "Meals to plan",
         dietOptions: {
@@ -246,16 +249,16 @@ export const translations = {
             copyFailed: "Couldn't copy automatically. Please select the text above and copy it manually."
         },
         apiKeySecurity: {
-            title: "API Key Storage Notice",
+            title: "Your API key will be stored in your browser",
             description: "Your API key will be stored in your browser's local storage in plain text.",
             risks: "This means:",
             risk1: "Anyone with access to this device can view your API key",
             risk2: "Browser extensions may be able to read it",
             risk3: "The key persists until you clear browser data",
             risk4: "The key will be visible in network requests (browser DevTools, network logs, proxies)",
-            recommendation: "For better security, consider using Copy & Paste mode instead, which doesn't store any credentials.",
+            usage: "The key is only used to call Google Gemini directly from your browser, for recipes, images and chat. No request passes through a server of this app.",
             understand: "I understand, continue",
-            useCopyPaste: "Use Copy & Paste instead"
+            cancel: "Cancel"
         },
         clearApiKey: {
             title: "Clear API Key?",
@@ -292,7 +295,7 @@ export const translations = {
             pullingTooltip: "Loading from GitHub…",
             disabledTooltip: "Sync is off",
             errorTooltip: "Sync error — click for details",
-            securityTitle: "GitHub Token Storage Notice",
+            securityTitle: "Your GitHub token will be stored in your browser",
             securityDescription: "To sync across devices, your GitHub Personal Access Token will be stored in your browser's local storage in plain text.",
             securityRisks: "Please understand:",
             securityRisk1: "Only create a token with the 'gist' scope — nothing more.",
@@ -383,11 +386,14 @@ export const translations = {
             quotaExceeded: "Kontingent für die Foto-Erkennung erschöpft. Bitte später erneut versuchen.",
         },
         photoPrivacy: {
-            title: "Zutat per Foto erkennen",
-            description: "Mache oder wähle ein Foto einer einzelnen Zutat. Das Bild wird an Google Gemini gesendet, das den Namen der Zutat zurückgibt.",
-            note: "Das Foto verlässt dein Gerät. Diese App speichert es nicht, aber es gelten die Bedingungen von Google.",
+            title: "Dein Foto wird an Google gesendet",
+            description: "Zum Erkennen der Zutat wird das Bild an Google Gemini hochgeladen, das den Namen der Zutat zurückgibt.",
+            beforeYouSend: "Bevor du sendest:",
+            note1: "Das Foto verlässt dein Gerät und wird auf Googles Servern verarbeitet.",
+            note2: "Achte darauf, dass keine Personen, Dokumente oder anderes mit im Bild sind.",
+            usage: "Diese App speichert das Foto nicht, es gelten aber Googles Bedingungen und Datenverarbeitung.",
             cancel: "Abbrechen",
-            understand: "Fortfahren",
+            send: "Foto senden",
         },
         meals: "Anzahl Mahlzeiten",
         dietOptions: {
@@ -575,16 +581,16 @@ export const translations = {
             copyFailed: "Automatisches Kopieren fehlgeschlagen. Bitte markiere den Text oben und kopiere ihn manuell."
         },
         apiKeySecurity: {
-            title: "Hinweis zur API-Schlüssel-Speicherung",
+            title: "Dein API-Schlüssel wird im Browser gespeichert",
             description: "Dein API-Schlüssel wird im lokalen Speicher deines Browsers als Klartext gespeichert.",
             risks: "Das bedeutet:",
             risk1: "Jeder mit Zugang zu diesem Gerät kann deinen API-Schlüssel einsehen",
             risk2: "Browser-Erweiterungen können ihn möglicherweise auslesen",
             risk3: "Der Schlüssel bleibt gespeichert, bis du die Browserdaten löschst",
             risk4: "Der Schlüssel ist in Netzwerkanfragen sichtbar (Browser-DevTools, Netzwerkprotokolle, Proxys)",
-            recommendation: "Für mehr Sicherheit empfehlen wir den Kopieren & Einfügen-Modus, der keine Zugangsdaten speichert.",
+            usage: "Der Schlüssel wird ausschließlich verwendet, um Google Gemini direkt aus deinem Browser aufzurufen — für Rezepte, Bilder und Chat. Keine Anfrage läuft über einen Server dieser App.",
             understand: "Verstanden, fortfahren",
-            useCopyPaste: "Kopieren & Einfügen verwenden"
+            cancel: "Abbrechen"
         },
         clearApiKey: {
             title: "API-Schlüssel löschen?",
@@ -621,7 +627,7 @@ export const translations = {
             pullingTooltip: "Lade von GitHub…",
             disabledTooltip: "Synchronisation ist aus",
             errorTooltip: "Sync-Fehler — klicken für Details",
-            securityTitle: "Hinweis zur Speicherung des GitHub-Tokens",
+            securityTitle: "Dein GitHub-Token wird im Browser gespeichert",
             securityDescription: "Für die Synchronisation zwischen Geräten wird dein GitHub Personal Access Token im lokalen Browser-Speicher im Klartext abgelegt.",
             securityRisks: "Bitte beachte:",
             securityRisk1: "Erstelle den Token ausschließlich mit dem Scope 'gist' — nicht mehr.",
@@ -712,11 +718,14 @@ export const translations = {
             quotaExceeded: "Quota d'identification par photo dépassé. Veuillez réessayer plus tard.",
         },
         photoPrivacy: {
-            title: "Identifier un ingrédient à partir d'une photo",
-            description: "Prenez ou choisissez une photo d'un seul ingrédient. L'image est envoyée à Google Gemini, qui renvoie le nom de l'ingrédient.",
-            note: "La photo quitte votre appareil. Cette application ne la stocke pas, mais les conditions de Google s'appliquent.",
+            title: "Votre photo sera envoyée à Google",
+            description: "Pour identifier un ingrédient, l'image est envoyée à Google Gemini, qui renvoie le nom de l'ingrédient.",
+            beforeYouSend: "Avant d'envoyer :",
+            note1: "La photo quitte votre appareil et est traitée sur les serveurs de Google.",
+            note2: "Veillez à ce qu'aucune personne, aucun document ni rien d'autre ne figure sur l'image.",
+            usage: "Cette application ne conserve pas la photo, mais les conditions et le traitement des données de Google s'appliquent.",
             cancel: "Annuler",
-            understand: "Continuer",
+            send: "Envoyer la photo",
         },
         meals: "Repas à planifier",
         dietOptions: {
@@ -904,16 +913,16 @@ export const translations = {
             copyFailed: "La copie automatique a échoué. Veuillez sélectionner le texte ci-dessus et le copier manuellement."
         },
         apiKeySecurity: {
-            title: "Avis de stockage de clé API",
+            title: "Votre clé API sera stockée dans votre navigateur",
             description: "Votre clé API sera stockée dans le stockage local de votre navigateur en texte clair.",
             risks: "Cela signifie :",
             risk1: "Toute personne ayant accès à cet appareil peut voir votre clé API",
             risk2: "Les extensions de navigateur peuvent potentiellement la lire",
             risk3: "La clé persiste jusqu'à ce que vous effaciez les données du navigateur",
             risk4: "La clé sera visible dans les requêtes réseau (DevTools du navigateur, journaux réseau, proxys)",
-            recommendation: "Pour plus de sécurité, envisagez d'utiliser le mode Copier-Coller, qui ne stocke aucune information d'identification.",
+            usage: "La clé sert uniquement à appeler Google Gemini directement depuis votre navigateur, pour les recettes, les images et le chat. Aucune requête ne passe par un serveur de cette application.",
             understand: "Je comprends, continuer",
-            useCopyPaste: "Utiliser Copier-Coller"
+            cancel: "Annuler"
         },
         clearApiKey: {
             title: "Effacer la clé API ?",
@@ -950,7 +959,7 @@ export const translations = {
             pullingTooltip: "Chargement depuis GitHub…",
             disabledTooltip: "Synchronisation désactivée",
             errorTooltip: "Erreur de synchronisation — cliquer pour les détails",
-            securityTitle: "Avertissement sur le stockage du jeton GitHub",
+            securityTitle: "Votre jeton GitHub sera stocké dans votre navigateur",
             securityDescription: "Pour synchroniser entre appareils, votre jeton d'accès personnel GitHub sera stocké en clair dans le stockage local du navigateur.",
             securityRisks: "À noter :",
             securityRisk1: "Créez un jeton uniquement avec la portée 'gist' — rien de plus.",
@@ -1041,11 +1050,14 @@ export const translations = {
             quotaExceeded: "Cuota de identificación por foto agotada. Por favor, inténtalo más tarde.",
         },
         photoPrivacy: {
-            title: "Identificar ingrediente desde una foto",
-            description: "Toma o elige una foto de un único ingrediente. La imagen se envía a Google Gemini, que devuelve el nombre del ingrediente.",
-            note: "La foto sale de tu dispositivo. Esta aplicación no la almacena, pero se aplican los términos de Google.",
+            title: "Tu foto se enviará a Google",
+            description: "Para identificar un ingrediente, la imagen se envía a Google Gemini, que devuelve el nombre del ingrediente.",
+            beforeYouSend: "Antes de enviar:",
+            note1: "La foto sale de tu dispositivo y se procesa en los servidores de Google.",
+            note2: "Asegúrate de que no aparezcan personas, documentos ni nada más en la imagen.",
+            usage: "Esta aplicación no almacena la foto, pero se aplican las condiciones y el tratamiento de datos de Google.",
             cancel: "Cancelar",
-            understand: "Continuar",
+            send: "Enviar foto",
         },
         meals: "Comidas a planificar",
         dietOptions: {
@@ -1233,16 +1245,16 @@ export const translations = {
             copyFailed: "No se pudo copiar automáticamente. Por favor, selecciona el texto de arriba y cópialo manualmente."
         },
         apiKeySecurity: {
-            title: "Aviso de almacenamiento de clave API",
+            title: "Tu clave API se almacenará en tu navegador",
             description: "Tu clave API se almacenará en el almacenamiento local de tu navegador en texto plano.",
             risks: "Esto significa:",
             risk1: "Cualquier persona con acceso a este dispositivo puede ver tu clave API",
             risk2: "Las extensiones del navegador pueden leerla",
             risk3: "La clave permanece hasta que borres los datos del navegador",
             risk4: "La clave será visible en solicitudes de red (DevTools del navegador, registros de red, proxies)",
-            recommendation: "Para mayor seguridad, considera usar el modo Copiar y Pegar, que no almacena ninguna credencial.",
+            usage: "La clave solo se usa para llamar a Google Gemini directamente desde tu navegador, para recetas, imágenes y chat. Ninguna solicitud pasa por un servidor de esta aplicación.",
             understand: "Entiendo, continuar",
-            useCopyPaste: "Usar Copiar y Pegar"
+            cancel: "Cancelar"
         },
         clearApiKey: {
             title: "¿Eliminar clave API?",
@@ -1279,7 +1291,7 @@ export const translations = {
             pullingTooltip: "Cargando desde GitHub…",
             disabledTooltip: "Sincronización desactivada",
             errorTooltip: "Error de sincronización — haga clic para más detalles",
-            securityTitle: "Aviso sobre el almacenamiento del token de GitHub",
+            securityTitle: "Tu token de GitHub se almacenará en tu navegador",
             securityDescription: "Para sincronizar entre dispositivos, su token de acceso personal de GitHub se almacenará en texto plano en el almacenamiento local del navegador.",
             securityRisks: "Tenga en cuenta:",
             securityRisk1: "Cree un token solo con el alcance 'gist' — nada más.",

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -10,12 +10,17 @@ import { useEffect, useRef } from 'react';
  * - Handles Escape key to close the dialog
  *
  * @param onClose - Callback to close the dialog (called on Escape key)
+ * @param focusContainer - Focus the dialog itself instead of its first control.
+ *   Use this where no button is a safe default: the emphasised button is then
+ *   not the one Enter would trigger, so Enter is left doing nothing.
  * @returns ref - Ref to attach to the dialog container element
  */
-export function useFocusTrap(onClose: () => void) {
+export function useFocusTrap(onClose: () => void, focusContainer = false) {
     const dialogRef = useRef<HTMLDivElement>(null);
     const previousFocusRef = useRef<HTMLElement | null>(null);
     const onCloseRef = useRef(onClose);
+    // Read once on mount, like onCloseRef, so the effect stays dependency-free
+    const focusContainerRef = useRef(focusContainer);
 
     // Keep the ref up to date without re-running the effect
     useEffect(() => {
@@ -49,7 +54,9 @@ export function useFocusTrap(onClose: () => void) {
         const isAlreadyFocusedInside = dialogRef.current?.contains(document.activeElement);
 
         if (!isAlreadyFocusedInside) {
-            if (focusableElements.length > 0) {
+            if (focusContainerRef.current) {
+                dialogRef.current?.focus();
+            } else if (focusableElements.length > 0) {
                 focusableElements[0].focus();
             } else {
                 // If no focusable elements, focus the dialog itself

--- a/src/index.css
+++ b/src/index.css
@@ -209,6 +209,20 @@ button {
     box-shadow: 0 4px 6px -1px hsla(var(--hue-primary), 60%, 40%, 0.2);
   }
 
+  /* Dialog buttons carry meaning through colour, so the three roles are
+     classes rather than ad-hoc utilities: btn-primary marks the action that
+     ends an exposure of the user's data, btn-warning the action that creates
+     one, and btn-quiet an action that changes nothing at all — cancel, close,
+     go back. Anything that destroys user content stays red, which is why no
+     dialog uses red any more: none of them destroys anything. */
+  .btn-warning {
+    @apply bg-warning-fill text-text-on-warning shadow-md hover:bg-warning-fill-hover disabled:opacity-60 disabled:cursor-not-allowed disabled:shadow-none;
+  }
+
+  .btn-quiet {
+    @apply bg-transparent text-text-muted hover:text-text-main hover:bg-bg-surface-hover disabled:opacity-60 disabled:cursor-not-allowed;
+  }
+
   .btn-icon {
     @apply p-2 bg-transparent text-text-muted rounded-md hover:text-text-main hover:bg-bg-surface-hover;
   }


### PR DESCRIPTION
## What

Follow-up to #288, which fixed the warning button's contrast and weight and in
doing so exposed a bigger inconsistency underneath. Across the six security
dialogs, nothing about a dialog predicted what its buttons meant:

- Green marked the safe choice in two dialogs and the confirming action in the
  other four.
- Red sat on "Yes, clear it" and "Disable sync" — the two actions that *reduce*
  exposure, and neither of which destroys anything recoverable. Elsewhere in the
  app red means deleting a pantry item or a kitchen, which is real content loss.
- The API key and gist warnings are the same dialog with the same label
  (`I understand, continue`), laid out as mirror images of each other.
- The dismissive button appeared as green, as neutral-with-border, or as
  transparent, depending on the dialog.

## Design & UX

Destructiveness alone does not order these choices — **exposure** does. Clearing
an API key destroys something, but it ends the exposure the dialog is about,
while keeping the key prolongs it. Colour now follows that axis:

| class | meaning |
|---|---|
| `btn-warning` | the action puts data somewhere it can be read |
| `btn-primary` | the action ends an exposure that is already running |
| `btn-quiet` | the action changes nothing — cancel, close, go back |
| red | irreversible loss of user content, so **no dialog uses it** |

Per dialog:

| # | Dialog | Top | Bottom |
|---|---|---|---|
| 1 | API key security | `I understand, continue` — **warning** | `Cancel` — **quiet** (was green, on top, labelled "Use Copy & Paste instead") |
| 2 | Gist token warning | `I understand, continue` — **warning** | `Cancel` — **quiet** (was green) |
| 3 | Clear API key | `Yes, clear it` — **primary** (was red, below) | `No, keep it` — **quiet** |
| 4 | Disable sync | `Disable sync` — **primary** (was red) | `Close` — **quiet** (was green) |
| 5 | Photo privacy | `Send photo` — **warning** (was green `Continue`) | `Cancel` — **quiet** |
| 6 | Gist setup | `Create new Gist`, `Use existing Gist` — both **warning** | `Close` — **quiet** |

`ReplaceRecipeDialog` and `CopyPasteDialog` are untouched: they carry no exposure
dimension, and their horizontal cancel-left / confirm-right row is the right
convention for a form.

**No button is a default any more.** The emphasised button is now the risky one,
so making Enter trigger it would satisfy the "the emphasised button is the one
Enter fires" convention in the worst possible way. Rather than emphasise one
button and focus another, `useFocusTrap` gains an opt-in to focus the dialog
container itself — there is then no default button to contradict, and Enter does
nothing until the user picks one. Escape still closes, and Tab from the
container lands on the first button. Dialog 6 is unaffected: its token input
carries `autoFocus`, and the trap already leaves focus alone when something
inside holds it.

The `Trash2` icon is dropped from "Yes, clear it": its only job was reinforcing
a red danger framing that is now gone, and a trash can on a green button sends
two opposite signals.

## Details

### Copy

The three consent dialogs now share one shape — a declarative title naming what
happens, a sentence on what is stored or sent, a short list, then what the
credential or photo is actually used for.

Dialog 1 loses its closing "for better security, consider Copy & Paste instead",
which recommended a route rather than describing the risk, and gains the
parallel to dialog 2: *the key is only used to call Google Gemini directly from
your browser — no request passes through a server of this app*, which
`src/services/llm.ts` bears out. With the recommendation gone, its button has
nothing to point at, so it becomes a plain `Cancel`.

Dialog 5 was the weakest of the three — a feature title and one sentence — while
being the only place in the app where image data leaves the device. It gains the
same structure, which is what earns it an amber button rather than overstating a
"Continue".

Titles become declarative in all three: *Your API key will be stored in your
browser*, *Your GitHub token will be stored in your browser*, *Your photo will be
sent to Google*.

Keys renamed: `apiKeySecurity.recommendation` → `usage`, `apiKeySecurity.useCopyPaste`
→ `cancel`, `photoPrivacy.understand` → `send`, `photoPrivacy.note` → `beforeYouSend`
+ `note1` + `note2` + `usage`. All in en, de, fr and es.

### Behaviour

The API key warning fired on **every** switch into API-key mode, including when a
key was already stored and the switch therefore exposed nothing new — a path the
app creates itself by offering "No, keep it" when leaving the mode. `Header.tsx:36`
gated the mount-time appearance behind `API_KEY_WARNING_SEEN`, but
`handleModeToggle` ignored the flag entirely.

It now appears only while no key is stored and only until acknowledged, matching
dialogs 2 and 5. The header's existing `apiKeyStoredWarning` tooltip already
carries the standing reminder for the "copy-paste mode, key still stored" state.
The decline handler's branch into dialog 3 stays reachable through the mount
path, so it does not become dead code.

## Testing

`npm run lint` and `npm run build` pass.

The one new foreground/background pairing is `btn-quiet`, computed against the
composited dialog panel:

| | light | dark |
|---|---|---|
| quiet label on the dialog panel | 4.92:1 | 5.96:1 |
| quiet label once hovered | 16.12:1 | 12.38:1 |
| focus ring against the panel (≥3:1) | 4.59:1 | 7.62:1 |

All six dialogs were rendered from the production stylesheet in both themes and
inspected.

Not run: no automated visual regression or axe pass exists in this repo, and the
`useFocusTrap` change has no test to extend — the hook is currently untested.

## Notes for review

Two things worth a second opinion, both deliberate:

- Dialog 6 now has two amber buttons of equal weight stacked on each other.
  Both genuinely expose data, so both are amber, but it is harder to scan than
  the old green/neutral pair.
- A green "Yes, clear it" reads unusually at first. It is the honest colour under
  the exposure rule, and the dialog itself is the confirmation step, but it is
  the change most likely to surprise.

---

- [x] New strings added to all four languages (en, de, es, fr)
- [x] New panels are collapsible, state persisted to localStorage — no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.10.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bh3TtxHHmzyEjgWyJL1RV7)_