### PR TITLE
fix(api-key): only treat the security warning as seen once accepted

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -175,7 +175,9 @@ export const Header: React.FC<HeaderProps> = ({
     };
 
     const handleSecurityCancel = () => {
-        markApiKeyWarningSeen();
+        // Deliberately no markApiKeyWarningSeen(): declining the warning is not
+        // acknowledging it, so a later switch to API Key mode must ask again —
+        // same as the Gist and photo dialogs, which only record consent on accept.
         setShowSecurityDialog(false);
 
         // Ask if user wants to clear or keep the API key


### PR DESCRIPTION
## What

Declining the API key security dialog recorded the warning as seen. Because `handleModeToggle` skips the dialog whenever `API_KEY_WARNING_SEEN` is set, a user who cancelled — and therefore never got a key stored, never agreed to one being stored — was switched straight into API Key mode on the next toggle, with no warning. The one path that says "no thanks" was the one path that permanently silenced the warning.

Consent is now recorded on accept only.

## Design & UX

The Gist token dialog (`GistSyncDialog.handleAcceptWarning`) and the photo privacy dialog (`PantryInput.handlePhotoPrivacyAccept`) both already persist their flag only when accepted; their cancel handlers just close. The API key dialog was the odd one out, so this is Rule 1 (consistency) as much as Rule 7 (keep users in control) — a decline should not quietly cost the user a safeguard they never waived.

The cancel path is otherwise untouched: the mode still does not flip, and the user is still asked whether to clear or keep an existing key.

## Details

Persistence: `api_key_warning_seen` in localStorage. The flag is now written in exactly one place, `handleSecurityAccept`.

Two paths were checked for re-showing the dialog where it isn't wanted:

- **Mount check** (`!hasSeenApiKeyWarning() && !!apiKey && !useCopyPaste`) — after a cancel the key is either cleared (`apiKey` empty) or kept with `useCopyPaste` set to true, so the condition is false either way. No dialog on reload.
- **Toggle check** (`if (apiKey || hasSeenApiKeyWarning())`) — a stored key still short-circuits, so nobody who already has a key gets asked again. The dialog returns only when no key is stored, which is the case the warning is actually about.

No migration needed: users who previously accepted keep their flag, and users who previously cancelled see the warning once more the next time they switch — which is the intent.

## Testing

`npm run lint` and `npm run build` pass. The behaviour change itself was traced through the handlers and the two guards above rather than exercised in a browser; there is no test suite in the repo.

---

- [ ] New strings added to all four languages (en, de, es, fr) — none added
- [ ] New panels are collapsible, state persisted to localStorage — no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — deliberately not; recent single-fix PRs (#287–#289) leave the bump to a separate release commit


---
_Generated by [Claude Code](https://claude.ai/code/session_01URZxUBqWRMRvvj4uJZpdCc)_