### PR TITLE
fix(a11y): let the keyboard reach the info tooltips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.12.0
+**Current version**: 1.12.1
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ui/TooltipButton.tsx
+++ b/src/components/ui/TooltipButton.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import React, { useId, useState, type ReactNode } from 'react';
 
 interface TooltipButtonProps {
     onClick?: () => void;
@@ -25,7 +25,14 @@ export const TooltipButton: React.FC<TooltipButtonProps> = ({
     rel,
     className = '',
 }) => {
+    const tooltipId = useId();
+    // Escape hides a tooltip the pointer or the keyboard is still sitting on
+    // (WCAG 1.4.13). The next hover or focus arms it again.
+    const [dismissed, setDismissed] = useState(false);
     const combinedClasses = `${baseButtonClasses} ${className}`.trim();
+    // Plenty of callers pass the same string as label and tooltip. Pointing a
+    // description at it too would have the screen reader read it out twice.
+    const describedBy = ariaLabel === tooltip ? undefined : tooltipId;
 
     const renderElement = () => {
         if (href) {
@@ -36,6 +43,7 @@ export const TooltipButton: React.FC<TooltipButtonProps> = ({
                     rel={rel}
                     className={combinedClasses}
                     aria-label={ariaLabel}
+                    aria-describedby={describedBy}
                 >
                     {icon}
                 </a>
@@ -48,27 +56,55 @@ export const TooltipButton: React.FC<TooltipButtonProps> = ({
                     onClick={onClick}
                     className={combinedClasses}
                     aria-label={ariaLabel}
+                    aria-describedby={describedBy}
                 >
                     {icon}
                 </button>
             );
         }
-        // Non-interactive tooltip (info icons)
+        // Info icons carry no action, but a tooltip that cannot take focus is
+        // one only pointer users ever get to read — and on touch, where there
+        // is no hover, nobody does. A real button is focusable without a
+        // tabIndex; role="img" would describe neither the element nor what
+        // focusing it does. cursor-help keeps the pointer from promising a
+        // click that leads nowhere.
         return (
-            <span
-                className={combinedClasses}
+            <button
+                type="button"
+                className={`${combinedClasses} cursor-help`}
                 aria-label={ariaLabel}
-                role="img"
+                aria-describedby={describedBy}
             >
                 {icon}
-            </span>
+            </button>
         );
     };
 
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        // Focus sits inside the container whenever this handler runs, so the
+        // tooltip is on screen unless it was already dismissed. Swallow that
+        // first Escape: dialogs and popovers listen for it on document, and
+        // closing one out from under the user is not what the press asked for.
+        // A second press reaches them.
+        if (e.key === 'Escape' && !dismissed) {
+            setDismissed(true);
+            e.stopPropagation();
+        }
+    };
+
+    const arm = () => setDismissed(false);
+
     return (
-        <div className="tooltip-container">
+        <div
+            className={`tooltip-container${dismissed ? ' tooltip-dismissed' : ''}`}
+            onKeyDown={handleKeyDown}
+            onFocus={arm}
+            onBlur={arm}
+            onMouseEnter={arm}
+            onMouseLeave={arm}
+        >
             {renderElement()}
-            <div className="tooltip-text">
+            <div id={tooltipId} role="tooltip" className="tooltip-text">
                 {tooltip}
             </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -162,10 +162,6 @@ body {
   width: 100%;
 }
 
-button {
-  cursor: pointer;
-}
-
 /* One focus treatment for the whole app, so the indicator looks the same
    wherever the keyboard lands. `outline` follows border-radius, stays out of
    the layout and needs no ring-offset colour — Tailwind's default offset is
@@ -195,6 +191,14 @@ button {
   :focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
+  }
+
+  /* In @layer base so a utility can override it. Unlayered, this beat every
+     layered class: `disabled:cursor-not-allowed` on the button styles below
+     never took effect, and the info tooltips could not swap in cursor-help to
+     stop promising a click that leads nowhere. */
+  button {
+    cursor: pointer;
   }
 
   /* Elements that only take focus programmatically — the skip-link target, the
@@ -282,19 +286,25 @@ button {
     @apply relative inline-block;
   }
 
+  /* No pointer-events-none: WCAG 1.4.13 asks that the pointer can travel onto
+     the tooltip without it vanishing, which matters at high magnification
+     where the text may not fit beside the trigger. While hidden, `invisible`
+     already keeps it out of the way of everything underneath. */
   .tooltip-text {
-    @apply invisible absolute z-50 bottom-[125%] left-1/2 -ml-[100px] w-[200px] p-2 bg-bg-surface text-text-main text-center text-xs border border-border-base rounded-md shadow-glass opacity-0 transition-opacity duration-300 pointer-events-none;
+    @apply invisible absolute z-50 bottom-[125%] left-1/2 -ml-[100px] w-[200px] p-2 bg-bg-surface text-text-main text-center text-xs border border-border-base rounded-md shadow-glass opacity-0 transition-opacity duration-300;
   }
 
-  .tooltip-container:hover .tooltip-text,
-  .tooltip-container:focus-within .tooltip-text {
+  /* .tooltip-dismissed is set while Escape holds a tooltip closed, and cleared
+     by the next hover or focus. */
+  .tooltip-container:not(.tooltip-dismissed):hover .tooltip-text,
+  .tooltip-container:not(.tooltip-dismissed):focus-within .tooltip-text {
     @apply visible opacity-100;
   }
 
   /* Lift a panel above its siblings while one of its tooltips is shown,
      so the tooltip overflow paints above the panel immediately above. */
-  .glass-panel:has(.tooltip-container:hover),
-  .glass-panel:has(.tooltip-container:focus-within) {
+  .glass-panel:has(.tooltip-container:not(.tooltip-dismissed):hover),
+  .glass-panel:has(.tooltip-container:not(.tooltip-dismissed):focus-within) {
     @apply relative z-50;
   }
 


### PR DESCRIPTION
## What

The info-icon variant of `TooltipButton` rendered a `<span role="img">` with no `tabIndex`. The tooltip is revealed only by `:hover` and `:focus-within`, so the explanation reached pointer users and nobody else — not the keyboard, and not touch, where there is no hover at all. Since these tooltips hang off `PanelHeader`, the gap repeated on every panel.

The variant now renders a real `<button type="button">`: focusable without a `tabIndex`, and honest about being something you land on, which `role="img"` was not. The tooltip element gets an `id` and `role="tooltip"`, and Escape dismisses it.

Closes #281.

## Design & UX

**Why a button and not `tabIndex={0}` on the span.** The issue left the role open. A focusable element carrying a description is a button in everything but name, so it became one — that also removes the `tabIndex` and keeps the semantics from drifting from the interaction. It clicks to nothing, which is why it gets `cursor-help`: the pointer should not promise an action that leads nowhere (Rule 1, consistency). Tapping it focuses it, so touch users get the tooltips they have never had.

**`aria-describedby` only where it adds something.** Most callers pass the same string as `ariaLabel` and `tooltip` — all three `PanelHeader` consumers do. Pointing a description at it as well would have the screen reader read the paragraph twice, so the association is skipped when the two are equal and applied when they differ (the sync button, whose label is "Sync settings" and whose tooltip is the live status). Worth a follow-up: those callers put a whole sentence in the accessible *name*, which is verbose for anyone browsing by button list. Changing that needs short strings in four languages and is a separate change.

**Escape swallows one press.** Dialogs and popovers listen for Escape on `document`. Letting the press through would close the dialog along with the tooltip, which is not what the press asked for (Rule 7, keep users in control). The first press closes the tooltip, a second reaches the dialog. Verified below on the one place this overlaps today, the kitchen popover.

**The cost, measured.** The 21 tab stops from the top of the page to "Generate Meal Plan" now include exactly one info icon — the Copy & Paste mode explanation in the header. The other four sit after the primary action. That number is constant: it does not grow with pantry contents, whereas the per-item edit and remove buttons do (24 stops at six ingredients, 56 at fifteen). This is the "explanations for novices" half of Rule 2, and it costs a single stop on the path that matters.

## Details

`button { cursor: pointer }` moved from unlayered CSS into `@layer base`. Unlayered, it outranked every layered class, so the info icon could not have taken `cursor-help` — and the `disabled:cursor-not-allowed` utilities already sitting in the button component styles never took effect either. They do now.

`pointer-events-none` is gone from `.tooltip-text`, so the pointer can travel onto the tooltip without it vanishing (WCAG 1.4.13, relevant under magnification). While hidden, `invisible` already keeps it clear of anything underneath.

The reveal rules gained `:not(.tooltip-dismissed)`, the class React sets while Escape holds a tooltip closed and clears on the next hover or focus.

No new strings, no persisted state, no network or prompt changes. The props contract is unchanged, so no consumer was touched.

## Testing

`npm run lint` and `npm run build` pass. Driven in a real browser with Playwright against the dev server, not read off the diff:

- Tabbed the full cycle in three states (empty, 6/8/3 items, 15/20/5). Every tooltip trigger is reachable and every one shows its tooltip on focus — no trigger came up hidden.
- Escape hides the tooltip and focus stays on the trigger; returning focus arms it again. Screenshots before and after confirm the focus ring survives the dismissal.
- Hover still reveals, and the tooltip stays open with the pointer resting on it.
- Kitchen popover open with focus on the "My Kitchen" info icon: first Escape dismisses the tooltip and leaves the popover open, second closes it. Escape from an ordinary control still closes it on the first press.

Not tested: a real screen reader. The ARIA wiring was verified structurally (`role="tooltip"`, matching `id`, `aria-describedby` present exactly where label and tooltip differ), not by listening to announcements.

---

- [x] New strings added to all four languages (en, de, es, fr) — none added
- [x] New panels are collapsible, state persisted to localStorage — no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.12.0 → 1.12.1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjJoVD8NxoZpVFoMdDfb9M)_