### PR TITLE
fix(a11y): honour prefers-reduced-motion across both animation systems

### DIFF
--- a/src/components/TimerTray.tsx
+++ b/src/components/TimerTray.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { Timer as TimerIcon, Pause, Play, X, Volume2, VolumeX } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { useTimers } from '../contexts/TimerContext';
@@ -20,6 +20,13 @@ export const TimerTray: React.FC = () => {
   const { timers, muted, toggleMuted, pauseTimer, resumeTimer, cancelTimer } = useTimers();
   const trayRef = useRef<HTMLDivElement>(null);
   const hasTimers = timers.length > 0;
+  // The root MotionConfig already drops transforms and the `layout` animation
+  // below, but not the explicit height keys — and those are the ones that move
+  // things: the tray is bottom-anchored, so a row growing in pushes the rows
+  // above it (and the running countdowns being read there) upwards, and the
+  // ResizeObserver republishes --timer-tray-height on every frame of the tween,
+  // which drags RecipeChat's float along with it on narrow screens.
+  const reducedMotion = useReducedMotion();
 
   useEffect(() => {
     const root = document.documentElement;
@@ -84,9 +91,9 @@ export const TimerTray: React.FC = () => {
                     <motion.li
                       key={timer.id}
                       layout
-                      initial={{ opacity: 0, height: 0 }}
-                      animate={{ opacity: 1, height: 'auto' }}
-                      exit={{ opacity: 0, height: 0 }}
+                      initial={reducedMotion ? { opacity: 0 } : { opacity: 0, height: 0 }}
+                      animate={reducedMotion ? { opacity: 1 } : { opacity: 1, height: 'auto' }}
+                      exit={reducedMotion ? { opacity: 0 } : { opacity: 0, height: 0 }}
                       className={`flex items-center gap-2 rounded-lg border p-2 overflow-hidden ${
                         amber
                           ? `bg-warning/10 border-warning/30 ${isDone ? 'animate-pulse' : ''}`

--- a/src/index.css
+++ b/src/index.css
@@ -317,3 +317,43 @@ body {
     @apply bg-primary-light rounded-md ring-4 ring-primary-light;
   }
 }
+
+/* Everything the CSS side animates — the ~15 animate-in fades, slides and
+   zooms, the theme cross-fade on body, the transition-colors on every control
+   — collapses to an instant change when the operating system asks for less
+   motion. Durations go to a hair above zero rather than `animation: none`, so
+   anything that waits for an animation to finish still gets its event and no
+   element is stranded mid-keyframe. Unlayered, so it outranks the utilities it
+   overrides.
+
+   Reducing motion must not cost feedback, which makes two exceptions:
+
+   animate-spin keeps turning, only slower. It is a small rotation in place —
+   not the travel across the viewport that provokes vestibular symptoms — and
+   at several call sites it is the entire message that the app is working
+   (PantryInput's inline lookups, the sync status in Header), where a frozen
+   spinner would read as a hang rather than as progress.
+
+   animate-pulse stops outright. It marks a finished timer, and both places
+   that use it — the inline chip and the tray row — already carry that state in
+   amber, in the word "done", through a swapped-in bell icon or a role="status"
+   announcement. Nothing about a finished timer becomes imperceptible without
+   it. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .animate-spin {
+    animation-duration: 1.5s !important;
+    animation-iteration-count: infinite !important;
+  }
+
+  .animate-pulse {
+    animation: none !important;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { MotionConfig } from 'framer-motion'
 import './index.css'
 import App from './App.tsx'
 import { SettingsProvider } from './contexts/SettingsContext'
@@ -10,15 +11,24 @@ import { ErrorBoundary } from './components/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ErrorBoundary>
-      <SettingsProvider>
-        <TimerProvider>
-          <CookingProgressProvider>
-            <App />
-            <TimerTray />
-          </CookingProgressProvider>
-        </TimerProvider>
-      </SettingsProvider>
-    </ErrorBoundary>
+    {/* One switch for every motion component in the app, present and future,
+        instead of a useReducedMotion call per component: with `user`, Framer
+        drops transform and layout animations when the OS asks for less motion
+        and keeps opacity, so enter/exit still fades and AnimatePresence
+        orchestrates exactly as before. Animations written as explicit
+        non-transform values — TimerTray's height — stay outside its reach and
+        opt out on their own. */}
+    <MotionConfig reducedMotion="user">
+      <ErrorBoundary>
+        <SettingsProvider>
+          <TimerProvider>
+            <CookingProgressProvider>
+              <App />
+              <TimerTray />
+            </CookingProgressProvider>
+          </TimerProvider>
+        </SettingsProvider>
+      </ErrorBoundary>
+    </MotionConfig>
   </StrictMode>,
 )


### PR DESCRIPTION
## What

`prefers-reduced-motion` appeared nowhere in the app, so every animation ran at full strength no matter what the operating system had been asked for. This adds one answer for each of the two animation systems: a root-level `MotionConfig` for Framer Motion, and a media block in `index.css` for everything CSS drives.

Closes #285.

## Design & UX

With the OS setting on, dialogs and panels appear instead of flying in, recipe cards stop arriving in a staggered cascade, the timer tray grows in one step rather than unfolding, and the theme switch cuts over instead of cross-fading. With the setting off nothing changes at all.

Reducing motion must not cost feedback (Rule 3, informative feedback), which made two exceptions worth deciding deliberately rather than by reflex:

- **`animate-spin` keeps turning, only slower (1.5s).** A small rotation in place is not the travel across the viewport that provokes vestibular symptoms, and at several call sites the spinner is the entire message that the app is working — `PantryInput.tsx:365` and the sync status in `Header.tsx:51` are an icon and nothing else. Frozen, it would read as a hang rather than as progress.
- **`animate-pulse` stops outright.** It marks a finished timer, and both places that use it already carry that state redundantly: amber tone, the word "Done!", a swapped-in bell icon on the chip, a `role="status"` announcement in the tray. Nothing about a finished timer becomes imperceptible without the pulse — verified in the browser, see below.

The alternative rejected for Framer Motion was a `useReducedMotion` call in each of the four motion components. `MotionConfig reducedMotion="user"` at the root is two lines, covers anything added later, and keeps opacity animating so `AnimatePresence` still orchestrates enter and exit exactly as before — which `TimerTray`'s `--timer-tray-height` bookkeeping depends on.

## Details

`MotionConfig` does not touch explicit non-transform values, so `TimerTray` opts its `height` keys out itself. The issue attributed that animation to reflow of surrounding content, which is not quite right — the tray is `fixed` and nothing in the document flow moves. What it does move is the tray's own rows (it is bottom-anchored, so a new row pushes the countdowns above it upwards) and, through the `ResizeObserver` republishing `--timer-tray-height` on every frame of the tween, `RecipeChat`'s float below `md`. Both stop under reduced motion.

The media block sets `animation-duration`/`transition-duration` to `0.01ms` rather than `animation: none`, so nothing is stranded mid-keyframe and any animation-completion handler still fires. There are none in the codebase today, but the safe form costs nothing. It is unlayered so it outranks the utilities it overrides.

Worth flagging, unrelated to this change: the ~15 `animate-in` / `fade-in` / `slide-in-from-*` / `zoom-in-95` classes the issue lists emit no CSS in this build. Those utilities come from `tailwindcss-animate` / `tw-animate-css`, neither of which is a dependency, and Tailwind v4 core does not ship them — the built stylesheet contains only the `spin` and `pulse` keyframes. They are inert today; the media block covers them if the plugin is ever added. Deciding whether to add it or drop the dead classes belongs in its own issue.

## Testing

`npm run lint` and `npm run build` pass.

Driven in Chromium (Playwright) against the production build, once with `reducedMotion: 'reduce'` and once with `'no-preference'`, comparing the two:

- **Full generate cycle** in copy-paste mode — Generate → copy-prompt dialog → paste response → recipes and shopping list rendered. Under reduce the dialog is at `opacity: 1, transform: none` on the first frame it is queryable; the recipe card settles at `opacity: 1, transform: none` in both modes.
- **Timer run to completion.** A 5-second timer taken to "Done!": under reduce the tray row and the chip report `animation-name: none` at `opacity: 1` while still showing "Done!" in amber; under no-preference the same elements report `animation-name: pulse` at a sampled opacity of 0.87. The done state stays perceptible either way.
- **Tray growth**, sampled ~one frame (32ms) after a second timer starts: under reduce the new row is already at its full 70px and `--timer-tray-height` is already 218px; under no-preference the row is 30px and the variable 178px, tweening to the same values. That is exactly the motion the `TimerTray` change removes.
- Computed styles confirmed directly: `body` transition `0.3s → 1e-05s`, `.animate-spin` `1s → 1.5s` and still `infinite`, `.animate-pulse` `2s infinite → none`.

Not tested: a real Gemini API generate cycle (no key available) — the copy-paste path exercises the same rendering, but not the `animate-spin` button state during a live request. That spinner's behaviour was verified through computed styles rather than in flight.

---

- [ ] New strings added to all four languages (en, de, es, fr) — n/a, no new strings
- [ ] New panels are collapsible, state persisted to localStorage — n/a, no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — deliberately not, at the maintainer's request

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1KweAcv57ys2wDHihS5Zt)_