### PR TITLE
fix(a11y): lift two hardcoded labels to the 12px floor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.12.1
+**Current version**: 1.12.2
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.12.1",
+  "version": "1.12.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/KitchenSwitcher.tsx
+++ b/src/components/KitchenSwitcher.tsx
@@ -167,7 +167,7 @@ const LocationField: React.FC<LocationFieldProps> = ({ kitchen, onSelect, onClea
                 href={OPEN_METEO.ATTRIBUTION_URL}
                 target="_blank"
                 rel="noreferrer"
-                className="text-[10px] text-text-muted hover:underline"
+                className="text-xs text-text-muted hover:underline"
             >
                 {t.kitchen.weatherAttribution}
             </a>

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -266,6 +266,16 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
             )}
 
             <div className="flex flex-col gap-8 flex-grow">
+                {/* Ingredients, instructions and nutrition stay hidden below `md`
+                    by deliberate choice. On a phone the grid card answers only
+                    "which of my planned meals do I cook today" and "what do I
+                    still have to buy" — the latter has its own section below.
+                    Everything else in the ingredient list is pantry stock the
+                    user already owns, and a quantity shortfall is meant to
+                    surface as a missing ingredient (see the pantry amount rules
+                    in services/llm.ts), not by reading amounts off the card.
+                    Cooking happens in the standalone view, which has the wake
+                    lock, larger type and the recipe chat. */}
                 <section className={isStandalone ? '' : 'hidden md:block'}>
                     <div className="flex items-center gap-2 mb-4 text-secondary">
                         <ListChecks size={20} />

--- a/src/components/TimerTray.tsx
+++ b/src/components/TimerTray.tsx
@@ -128,7 +128,7 @@ export const TimerTray: React.FC = () => {
                         <div className="flex-1 min-w-0">
                           <p className="text-xs text-text-muted line-clamp-2" title={timer.label}>{timer.label}</p>
                           {isFollowUp && !isDone && (
-                            <p className="text-[0.65rem] font-bold uppercase tracking-wider text-warning-text">
+                            <p className="text-xs font-bold uppercase tracking-wider text-warning-text">
                               {t.timers.followUp}
                             </p>
                           )}


### PR DESCRIPTION
Closes #286.

## What

Two labels sat below the app's `text-xs` (12px) floor as hardcoded sizes. Both now use `text-xs`:

- `KitchenSwitcher.tsx` — the Open-Meteo attribution link, previously `text-[10px]`
- `TimerTray.tsx` — the timer follow-up indicator, previously `text-[0.65rem]` (~10.4px)

The timer label is the more serious of the two: it carries functional state rather than decoration. #286 flagged it as "tiny *and* low-contrast", but the contrast half was already resolved when #280 moved that line to `text-warning-text`, so only the size remained. Verified in the browser at 12px / `rgb(150, 74, 8)`.

The second half of #286 asked for a decision, not necessarily a change — see below.

## Design & UX

**The mobile question: no change, and the reasoning is now recorded at the call site.**

#286 asked whether the recipe card should keep hiding ingredients and instructions below `md`, on the grounds that a phone user cannot compare what two recipes need without navigating into each one and back (Golden Rule 8). That framing does not survive contact with how the app works:

- The meal plan is not a menu to choose from — all N planned meals get cooked. The phone-side decision is "which of these do I cook today", not "which of these do I cook at all".
- The part of that decision that needs data is "what do I still have to buy", and the Need-to-Buy section is already visible on mobile.
- Everything else in the ingredient list is, by construction, pantry stock the user already owns — the recipes are generated from it, and rule 11 of the prompt makes the list include spice-rack items too.
- The one genuine counter-case is a quantity shortfall ("I have feta, but is 100g enough?"). `PantryItem` carries an `amount`, and rules 4-6 of the prompt tell the model to size portions realistically and put anything short into `missingIngredients`. So a shortfall is meant to surface in Need-to-Buy, not by reading amounts off the card.

Showing the full list on mobile would therefore add scrolling (against the "minimize scrolling" guidance) in exchange for information that is either already visible or already owned. Instructions stay hidden for the same reason plus one more: cooking happens in the focus view, which has the wake lock, larger type and the recipe chat. Nutrition — a third `hidden md:block` that #286 did not list — stays hidden by the same decision.

Alternatives considered and rejected: making the sections collapsible per the existing panel pattern (solves a comparison problem that isn't there, and adds a chevron to every desktop card); showing a collapsed ingredient summary (same); defaulting collapsed on mobile and expanded on desktop (two defaults on one persisted value).

## Details

No behaviour change, no new strings, no new persisted state. The mobile decision is captured as a comment above the first `hidden md:block` section in `RecipeCard.tsx` so the next audit pass finds the reasoning instead of re-raising it.

## Testing

`npm run lint` and `npm run build` both pass. No test suite in the repo.

Checked in Chromium at a 390px viewport with a seeded meal plan, per #286's "in the browser, not only in the markup":

- Open-Meteo attribution in the kitchen location editor: computed `12px`, renders on one line, right edge at 361px.
- Timer follow-up indicator: drove a `2-40 seconds` timer chip into its follow-up phase; the tray label computes to `12px` / `rgb(150, 74, 8)` and the tray stays within the viewport.
- `document.body.scrollWidth` is 390 at a 390px viewport — neither size bump introduced horizontal overflow.

---

- [ ] New strings added to all four languages (en, de, es, fr) — n/a, no new strings
- [ ] New panels are collapsible, state persisted to localStorage — n/a, no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` (1.12.1 → 1.12.2, patch)

---
_Generated by [Claude Code](https://claude.ai/code/session_013ferzf4cAMYeuhdLnxFSqF)_