### PR TITLE
docs: turn the design canon into repo commitments and split out Rule 2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,8 @@
 ## Design & UX
 
 <!-- User-facing changes only: the decisions taken and the alternatives
-     rejected. Reference the Eight Golden Rules where they applied. -->
+     rejected. Cite the Eight Golden Rules by number where they applied
+     (InterfaceDesign.md), and UniversalDesign.md for accessibility. -->
 
 ## Details
 
@@ -14,11 +15,13 @@
 
 ## Testing
 
-<!-- What was actually run, and what was not. -->
+<!-- What was actually run, and what was not. Include measured contrast
+     ratios for any new colour pairing. -->
 
 ---
 
-- [ ] New strings added to all four languages (en, de, es, fr)
+- [ ] New strings added to all four languages (en, de, es, fr) — accessible names included
+- [ ] New controls: focus visible, reachable by keyboard, state not carried by colour alone
 - [ ] New panels are collapsible, state persisted to localStorage
 - [ ] `npm run lint` and `npm run build` pass
 - [ ] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — or deliberately not

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@
 ---
 
 - [ ] New strings added to all four languages (en, de, es, fr) — accessible names included
-- [ ] New controls: focus visible, reachable by keyboard, state not carried by colour alone
+- [ ] New controls: focus visible, reachable by keyboard, state not carried by colour alone — and new motion checked under `prefers-reduced-motion`
 - [ ] New panels are collapsible, state persisted to localStorage
 - [ ] `npm run lint` and `npm run build` pass
 - [ ] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — or deliberately not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.12.2
+**Current version**: 1.12.3
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 
@@ -37,7 +37,8 @@ The code will be carefully reviewed by an expert for correctness, security, edge
 ### When Adding Features
 
 - **Usability First**: Keep interactions minimal. Avoid adding steps or dialogs unless necessary.
-- **Interace Design**: Adhere to the Eight Golden Rules of Interface Design: @InterfaceDesign.md
+- **Interface Design**: Adhere to the Eight Golden Rules of Interface Design, and to what each has come to mean here: @InterfaceDesign.md
+- **Universal Design**: Golden Rule 2 in full — the accessibility conventions this repo is bound to: @UniversalDesign.md
 - **Minimize clicks**: Use sensible defaults, persist user choices
 - **Minimize scrolling**: Use collapsible panels, keep important actions visible
 - **All panels should be collapsible** with state persisted to localStorage

--- a/InterfaceDesign.md
+++ b/InterfaceDesign.md
@@ -1,35 +1,100 @@
-# The Eight Golden Rules of Interface Design 
+# The Eight Golden Rules of Interface Design
 
-## 1. Strive for consistency.
+Shneiderman's eight rules, each followed by what it has come to mean in this
+codebase. The rule is the shared vocabulary; the note under it is the
+commitment already made and the artifact that carries it.
 
-Consistent sequences of actions should be required in similar situations; identical terminology should be used in prompts, menus, and help screens; and consistent color, layout, capitalization, fonts, and so on, should be employed throughout. Exceptions, such as required confirmation of the delete command or no echoing of passwords, should be comprehensible and limited in number
+Cite them by number in pull requests. A rule with nothing concrete under it is
+not yet a commitment — add the artifact rather than the aspiration.
 
-## 2. Seek universal usability.
+## 1. Strive for consistency
 
-Recognize the needs of diverse users and design for plasticity, facilitating transformation of content. Novice to expert differences, age ranges, disabilities, international variations, and technological diversity each enrich the spectrum of requirements that guides design. Adding features for novices, such as explanations, and features for experts, such as shortcuts and faster pacing, enriches the interface design and improves perceived quality.
+Identical sequences for identical situations, one term per concept, one visual
+treatment per role.
 
-## 3. Offer informative feedback.
+**Here:** one focus ring for the whole app, declared once in `@layer base`.
+`PanelHeader` for every panel, `Toggle` for every setting row, `.btn-primary` /
+`.btn-warning` / `.btn-quiet` for every dialog button. When a pattern exists,
+extend it instead of adding a variant beside it — #292 replaced eleven
+per-component focus treatments with one, and #291 collapsed three differently
+shaped settings controls onto a single row. Export and import stay icon
+buttons precisely because they are actions, not settings, and must not look
+like the switches.
 
-For every user action, there should be an interface feedback. For frequent and minor actions, the response can be modest, whereas for infrequent and major actions, the response should be more substantial. Visual presentation of the objects of interest provides a convenient environment for showing changes explicitly (see the discussion of direct manipulation in Chapter 7).
+## 2. Seek universal usability
 
-## 4. Design dialogs to yield closure.
+Novice and expert, age ranges, disabilities, international variation,
+technological diversity.
 
-Sequences of actions should be organized into groups with a beginning, middle, and end. Informative feedback at the completion of a group of actions gives users the satisfaction of accomplishment, a sense of relief, a signal to drop contingency plans from their minds, and an indicator to prepare for the next group of actions. For example, e-commerce websites move users from selecting products to the checkout, ending with a clear confirmation page that completes the transaction.
+**Here:** the accessibility conventions this repo is bound to are large enough
+to live in their own file — see @UniversalDesign.md. Beyond those: every
+visible string and every accessible name goes through `translations.ts` in all
+four languages, and recipe generation offers both a Copy-Paste route that needs
+no account and an API-key route for users who want one.
 
-## 5. Prevent errors.
+## 3. Offer informative feedback
 
-As much as possible, design the interface so that users cannot make serious errors; for example, gray out menu items that are not appropriate and do not allow alphabetic characters in numeric entry fields (Section 3.3.5). If users make an error, the interface should offer simple, constructive, and specific instructions for recovery. For example, users should not have to retype an entire name-address form if they enter an invalid zip code but rather should be guided to repair only the faulty part. Erroneous actions should leave the interface state unchanged, or the interface should give instructions about restoring the state.
+Every action gets a response, scaled to the weight of the action.
 
-## 6. Permit easy reversal of actions.
+**Here:** anything asynchronous carries a visually hidden `role="status"`
+region beside its visible indicator, so the spinner is not the only channel.
+Feedback outranks motion reduction: under `prefers-reduced-motion` the spinner
+keeps turning at 1.5s, because at several call sites the spinner *is* the
+entire message and a frozen one reads as a hang. `animate-pulse` may stop —
+what it marks is also said in words, in colour and in an announcement.
 
-As much as possible, actions should be reversible. This feature relieves anxiety, since users know that errors can be undone, and encourages exploration of unfamiliar options. The units of reversibility may be a single action, a data-entry task, or a complete group of actions, such as entry of a name-address block.
+## 4. Design dialogs to yield closure
 
-## 7. Keep users in control.
+Beginning, middle, end, with the end stated.
 
-Experienced users strongly desire the sense that they are in charge of the interface and that the interface responds to their actions. They don’t want surprises or changes in familiar behavior, and they are annoyed by tedious data-entry sequences, difficulty in obtaining necessary information, and inability to produce their desired result.
+**Here:** the three consent dialogs share one shape — a declarative title
+naming what happens, what is stored or sent, a short list of consequences, then
+what the credential or photo is actually used for (#289). Consent is recorded
+on accept only; dismissing a dialog closes nothing out (#290).
 
-## 8. Reduce short-term memory load.
+## 5. Prevent errors
 
-Humans’ limited capacity for information processing in short-term memory (the rule of thumb is that people can remember “seven plus or minus two chunks” of information) requires that designers avoid interfaces in which users must remember information from one display and then use that information on another display. It means that cellphones should not require reentry of phone numbers, website locations should remain visible, and lengthy forms should be compacted to fit a single display.
+Make the serious mistake hard to make, and recovery specific when it happens.
 
-These underlying principles must be interpreted, refined, and extended for each environment. They have their limitations, but they provide a good starting point for mobile, desktop, and web designers. The principles presented in the ensuing sections focus on increasing users’ productivity by providing simplified data-entry procedures, comprehensible displays, and rapid informative feedback to increase feelings of competence, mastery, and control over the system.
+**Here:** dialog buttons are coloured by *exposure*, not by destructiveness
+(#289) — `btn-warning` puts data somewhere it can be read, `btn-primary` ends
+an exposure already running, `btn-quiet` changes nothing at all. Clearing an
+API key destroys something and is still green, because it ends the exposure the
+dialog is about. Red is reserved for irreversible loss of user content, which
+is why no dialog currently uses it. Where the emphasised button is the risky
+one, no button is a default: `useFocusTrap(onClose, true)` focuses the dialog
+itself and Enter does nothing until the user picks.
+
+## 6. Permit easy reversal of actions
+
+**Here:** `UndoToast` with an action, rather than a confirmation dialog in
+front of the deed. A confirmation taxes every correct action to catch the rare
+wrong one; an undo charges only the user who was actually wrong. Reserve
+dialogs for what an undo cannot walk back — data that has already left the
+device.
+
+## 7. Keep users in control
+
+No surprises, no changes to familiar behaviour, no tedious sequences.
+
+**Here:** every setting persists to localStorage, so nothing is asked twice.
+Escape closes any dialog. A tooltip's first Escape dismisses the tooltip only
+and is swallowed before it can close the dialog behind it; a second press gets
+through (#293). Nothing leaves the device without a switch having been flipped
+for it.
+
+## 8. Reduce short-term memory load
+
+Roughly seven plus or minus two chunks; never make users carry information
+between displays.
+
+**Here:** panels collapse with their state persisted, and the pantry stays on
+screen while a recipe is generated. Credentials are entered once and never
+re-asked. Accessible names carry their object — "Collapse: Diet", not
+"Collapse" — so a control is intelligible without remembering which heading it
+sat beneath.
+
+---
+
+Source: Ben Shneiderman, *Designing the User Interface*. The rules are quoted
+in condensed form; the commentary is this project's own.

--- a/InterfaceDesign.md
+++ b/InterfaceDesign.md
@@ -36,9 +36,12 @@ no account and an API-key route for users who want one.
 
 Every action gets a response, scaled to the weight of the action.
 
-**Here:** anything asynchronous carries a visually hidden `role="status"`
-region beside its visible indicator, so the spinner is not the only channel.
-Feedback outranks motion reduction: under `prefers-reduced-motion` the spinner
+**Here:** an asynchronous operation gets a visually hidden `role="status"`
+region beside its visible indicator, so the spinner is not the only channel —
+generation, the timers and the location search have one (#297). Known gap:
+`CopyPasteDialog` still announces a finished copy only by relabelling the
+button, which is disabled in the same moment. Feedback outranks motion
+reduction: under `prefers-reduced-motion` the spinner
 keeps turning at 1.5s, because at several call sites the spinner *is* the
 entire message and a frozen one reads as a hang. `animate-pulse` may stop —
 what it marks is also said in words, in colour and in an announcement.

--- a/UniversalDesign.md
+++ b/UniversalDesign.md
@@ -1,0 +1,164 @@
+# Universal Design
+
+Golden Rule 2 — *seek universal usability* — spelled out for this codebase.
+
+These are conventions, not principles: each one is a decision already taken,
+with the reason attached so it does not get re-litigated or quietly undone.
+Where a rule states a number, the number is checkable in a diff.
+
+The target is **WCAG 2.2 Level AA**.
+
+## Colour and contrast
+
+**Thresholds.** 4.5:1 for text, 3:1 for non-text — UI borders, meaningful
+icons, and the focus indicator (SC 1.4.11).
+
+**Never hardcode a palette colour.** No `amber-600`, no `text-white` on a
+filled control. Use the semantic tokens; they are declared three times over —
+in `@theme`, in `:root` and in the dark-mode block — because a token declared
+in only one of them silently stops switching themes (#279 found exactly that
+in `--color-border-base`).
+
+**One hue needs more than one token.** A colour used as a fill and the same
+colour used as text have opposite contrast requirements, and neither value
+works for the other:
+
+| Token | Role |
+| --- | --- |
+| `--color-warning` | the bright accent behind tints and borders |
+| `--color-warning-fill` / `-hover` | the solid fill under a button label |
+| `--color-warning-text` | amber as text, or as a meaningful icon |
+| `--color-text-on-warning` | the label on the fill |
+
+**A filled button must not outweigh its neighbours.** Contrast alone is not
+enough: at 50% lightness amber was 2.6× as bright as the primary fill, so the
+risky choice drew the eye more than the recommended one whatever colour its
+label was (#288). In light mode the warning fill therefore drops down the ramp
+until it carries white like primary does; in dark mode, where primary is itself
+light, it stays at full amber with a dark label. If you add a filled colour
+role, check its weight against primary, not just its contrast.
+
+**Colour is never the only carrier.** A finished timer says so in amber, in
+the word "Done!", with a swapped-in bell icon, and through a `role="status"`
+announcement. Any state that matters needs at least one non-colour channel.
+
+## Focus
+
+**One treatment for the entire app**: `2px solid var(--color-primary)` at 2px
+offset, on `:focus-visible`, declared in `@layer base`.
+
+- **Never write `focus:outline-none`.** Eleven components each had their own
+  focus variant before #292; several were invisible (a 1.14:1 ring, a hue
+  shift on a hairline border).
+- **Never use `ring-offset`.** Tailwind's default offset colour is white,
+  which drew a halo around every focused button in dark mode.
+- `outline-color` is pinned unconditionally in the base layer. Tailwind v4
+  animates it under `transition-colors`, so without the pin the ring fades in
+  from `currentColor` — white on white on a filled button.
+- **Prefer `transition-colors` over `transition-all`** on anything focusable;
+  `transition-all` animates the outline's width and the ring lags behind fast
+  tabbing.
+- Elements that only receive focus programmatically — `[tabindex="-1"]`, the
+  skip-link target, dialog panels holding a trap — get no ring. A ring around
+  a whole panel reads as an error.
+- Opting out is allowed where something else visibly carries the indicator
+  (the language pill, the inset ring on flush list items). That is why the
+  rule lives in `@layer base`: unlayered, no utility could override it.
+
+## Keyboard
+
+- The **skip link is the document's first tab stop**, parked above the
+  viewport until focused, and moves focus to `<main id="main-content">`.
+- **Anything that reveals information on hover must also reveal it on focus,
+  and must be focusable.** A `<span role="img">` is neither. On touch there is
+  no hover at all, so hover-only content reaches nobody there (#293).
+- Dialogs trap focus via `useFocusTrap`, restore focus on close, and close on
+  Escape.
+- Escape handlers on nested UI stop propagation for the first press, so
+  dismissing a tooltip does not also close the dialog behind it.
+
+## Accessible names
+
+- **Always translated.** Add to the `a11y` group in all four language objects
+  in `translations.ts`; never a hardcoded English literal. A screen-reader
+  user running the app in German heard English control names before #295.
+- **Name the object, not just the verb**: `` `${t.a11y.collapse}: ${title}` ``.
+  Seven collapse buttons announced a bare "Collapse" with nothing to say which
+  panel they meant.
+- **Match the visible label** (SC 2.5.3). Where a heading and an accessible
+  name quote the same words, give them one source — `appTitle` exists so the
+  `<h1>` and the accessible name cannot drift apart.
+- **Do not describe what is already announced.** Where a caller passes the
+  same string as label and tooltip, skip `aria-describedby` or the screen
+  reader reads it twice. Likewise drop a "(crossed off)" suffix when
+  `aria-pressed` already carries the state.
+
+## Live regions
+
+Dynamic changes invisible to assistive technology are the easiest defect to
+ship, and the fix has one trap in it:
+
+**A region announces changes to text it already had.** A region created in the
+same render that first fills it stays silent (#297). So:
+
+- Render a **permanent** `<p className="sr-only" role="status">` and change its
+  contents, rather than conditionally rendering the region.
+- Derive the message **while rendering** from state; do not push it on a
+  transition. This is also what keeps a per-second countdown out of the region.
+- **Put the point first.** State leads; an instruction sentence follows only
+  when it is needed to disambiguate.
+- **One region per concern.** Duplicate announcements are worse than none.
+- Report what is otherwise undiscoverable — the location search announces the
+  *number* of hits, which a screen-reader user cannot see.
+
+## Motion
+
+`prefers-reduced-motion` is already handled globally, in two places. **Do not
+add `useReducedMotion` per component.**
+
+- **Framer Motion**: `<MotionConfig reducedMotion="user">` at the root in
+  `main.tsx`. It covers every motion component present and future, drops
+  transforms and layout animations, and keeps opacity so `AnimatePresence`
+  still orchestrates enter and exit.
+- **CSS**: one `@media (prefers-reduced-motion: reduce)` block in `index.css`.
+  Durations collapse to a hair above zero rather than `animation: none`, so
+  anything awaiting an animation event still gets it and nothing is stranded
+  mid-keyframe.
+- **Animations of explicit non-transform values are outside MotionConfig's
+  reach** and must opt out themselves — `TimerTray` drops its height keys, or
+  its ResizeObserver would republish `--timer-tray-height` on every frame.
+- **Less motion must not mean less feedback.** The two documented exceptions
+  are in the CSS block; extend that comment if you add a third.
+
+## Type size and touch
+
+- **12px (`text-xs`) is the floor.** No `text-[10px]`, no `text-[0.65rem]` —
+  least of all on anything carrying functional state.
+- `cursor: pointer` only where a click does something. Info icons use
+  `cursor-help`; disabled controls use `disabled:cursor-not-allowed`, which
+  works only because `button { cursor: pointer }` sits in `@layer base`.
+- No `pointer-events-none` on a tooltip: SC 1.4.13 requires that the pointer
+  can travel onto it without it vanishing, which matters under magnification.
+
+## State on controls
+
+Use the role that already exists before inventing markup:
+
+| Control | Markup |
+| --- | --- |
+| Settings switch | `role="switch"` + `aria-checked` |
+| Collapsible panel | `aria-expanded` on the trigger |
+| Toggle button (mute, crossed-off) | `aria-pressed` |
+| Switch that opens a dialog instead of committing | `aria-haspopup="dialog"` |
+| Purely decorative icon beside a label | `aria-hidden="true"` |
+
+## Before opening a pull request
+
+- Tab through the change end to end. Every stop visibly ringed, nothing
+  reachable that does nothing, nothing interactive skipped.
+- Every new string in four languages, accessible names included.
+- New colour pairing? State the measured ratio in the PR body, as #287, #288
+  and #289 do.
+- Switch the OS to reduced motion and confirm feedback survives.
+- `<html lang>` follows the selected UI language — already wired; do not
+  regress it.

--- a/UniversalDesign.md
+++ b/UniversalDesign.md
@@ -63,7 +63,9 @@ offset, on `:focus-visible`, declared in `@layer base`.
   a whole panel reads as an error.
 - Opting out is allowed where something else visibly carries the indicator
   (the language pill, the inset ring on flush list items). That is why the
-  rule lives in `@layer base`: unlayered, no utility could override it.
+  rule lives in `@layer base` rather than outside the layers: Tailwind's
+  utilities sit in the later `@layer utilities` and can therefore override it.
+  Unlayered, it would outrank every utility and no opt-out would be possible.
 
 ## Keyboard
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.12.2",
+  "version": "1.12.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What

`InterfaceDesign.md` was a verbatim excerpt from Shneiderman, dangling references to "Chapter 7" and "Section 3.3.5" included. It is cited three times in the repo — in `AGENTS.md`, in the PR template, and as its own title — and all three are instructions to reference the rules rather than references. No commit or pull request has ever named a rule.

Two things were wrong with that. The rules are canonical enough that the model already knows them, so 4.3 KB of verbatim text bought recall it did not need. And none of the eight was falsifiable against a diff: nothing can be shown to violate "strive for consistency", which is why nobody cites them — you cannot win an argument with them.

The eight rules are now one line each, followed by what this codebase has actually decided under them and the change that decided it. Rule 2 needs more than a paragraph, so it becomes its own file.

## Design & UX

No user-facing change. The documents themselves were the design problem.

**Rule 1 (consistency)** applied to the docs as much as to the app: two design documents of different character — a quoted canon and a set of measured conventions — were previously going to end up in one file. They are now split along the line that actually separates them. `InterfaceDesign.md` is the taxonomy everyone already knows, and each rule points at the artifact that carries it: the exposure axis behind the dialog button colours under rule 5, `UndoToast`-over-confirmation under rule 6, the swallowed first Escape under rule 7. `UniversalDesign.md` is the one rule that needed depth.

The test applied to every line of the new files: *could a reviewer show a diff violates this?* Aspirations were cut; numbers and token names kept.

`UniversalDesign.md` collects what the eleven accessibility changes (#279, #287–#298) settled on:

- contrast thresholds, and why one hue needs four tokens rather than one
- the single focus ring, plus the three ways it was previously broken — `focus:outline-none`, `ring-offset`, `transition-all`
- live regions and the trap that a region filled in its own first render stays silent
- reduced motion handled globally in two places, so nothing should add a `useReducedMotion` call
- the 12px floor, cursor semantics, and which ARIA role each control already has

## Details

- `AGENTS.md`: the Interface Design bullet gains a sibling pointing at `@UniversalDesign.md`, so both files are transitively imported the way `InterfaceDesign.md` already was. Fixes the "Interace" typo on that line.
- PR template: an accessibility checkbox, a request for measured contrast ratios in Testing, and accessible names folded into the translations checkbox. Recent pull requests were already volunteering the ratios.
- No source files touched.

## Testing

`npm run lint` and `npm run build` both pass. The pre-existing chunk-size warning is unchanged.

Not verified: nothing to verify at runtime — the change is four Markdown files and a version bump.

---

- [x] New strings added to all four languages (en, de, es, fr) — accessible names included — *n/a, no strings*
- [x] New controls: focus visible, reachable by keyboard, state not carried by colour alone — *n/a, no controls*
- [x] New panels are collapsible, state persisted to localStorage — *n/a, no panels*
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.12.3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ59tYvi4t5eiE97obqbwN)_