### PR TITLE
fix(a11y): keep focus in the list after removing an entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.12.3
+**Current version**: 1.12.4
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.12.3",
+      "version": "1.12.4",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.12.3",
+  "version": "1.12.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/KitchenAppliances.tsx
+++ b/src/components/KitchenAppliances.tsx
@@ -1,7 +1,8 @@
-import React, { useState, forwardRef, useImperativeHandle } from 'react';
+import React, { useState, useRef, forwardRef, useImperativeHandle } from 'react';
 import { Plus, Trash2, ChefHat } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { PanelHeader } from './ui';
+import { useRemovalFocus } from '../hooks/useRemovalFocus';
 import { VALIDATION } from '../constants';
 
 export interface KitchenAppliancesRef {
@@ -25,6 +26,9 @@ export const KitchenAppliances = forwardRef<KitchenAppliancesRef, KitchenApplian
 }, ref) => {
     const { t } = useSettings();
     const [newAppliance, setNewAppliance] = useState('');
+    const listRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const rememberRemoval = useRemovalFocus(listRef, inputRef, '[data-remove-entry]', appliances.length);
 
     const flushPendingInput = (): string | null => {
         const trimmed = newAppliance.trim();
@@ -61,6 +65,7 @@ export const KitchenAppliances = forwardRef<KitchenAppliancesRef, KitchenApplian
                 <>
                     <form onSubmit={handleSubmit} className="flex flex-col gap-3">
                         <input
+                            ref={inputRef}
                             type="text"
                             placeholder={t.appliancesPlaceholder}
                             value={newAppliance}
@@ -74,19 +79,20 @@ export const KitchenAppliances = forwardRef<KitchenAppliancesRef, KitchenApplian
                         </button>
                     </form>
 
-                    <div className="flex flex-wrap gap-2 mt-2">
+                    <div ref={listRef} className="flex flex-wrap gap-2 mt-2">
                         {appliances.length === 0 && (
                             <div className="text-text-muted text-center py-4 italic w-full">
                                 {t.noAppliances}
                             </div>
                         )}
 
-                        {appliances.map((appliance) => (
+                        {appliances.map((appliance, index) => (
                             <div key={appliance} className="flex flex-row items-center gap-1 px-2 py-0.5 rounded-full border border-border-base bg-bg-surface shadow-sm hover:border-border-hover transition-colors">
                                 <span className="font-medium text-xs text-text-main">{appliance}</span>
                                 <button
                                     type="button"
-                                    onClick={() => onRemoveAppliance(appliance)}
+                                    data-remove-entry
+                                    onClick={() => { rememberRemoval(index); onRemoveAppliance(appliance); }}
                                     className="text-red-500 hover:text-red-600 hover:bg-red-500/10 rounded-full p-0.5 transition-colors"
                                     aria-label={`${t.remove}: ${appliance}`}
                                 >

--- a/src/components/PantryInput.tsx
+++ b/src/components/PantryInput.tsx
@@ -1,10 +1,11 @@
-import React, { useState, forwardRef, useImperativeHandle, useRef, useEffect } from 'react';
+import React, { useState, forwardRef, useImperativeHandle, useRef, useEffect, useCallback } from 'react';
 import { Plus, Trash2, Refrigerator, Info, Loader2, X, Camera } from 'lucide-react';
 import type { PantryItem, Notification } from '../types';
 import { generateId } from '../utils/idGenerator';
 import { useSettings } from '../contexts/SettingsContext';
 import { useStorageTips } from '../hooks/useStorageTips';
 import { useLocalStorage } from '../hooks/useLocalStorage';
+import { useRemovalFocus } from '../hooks/useRemovalFocus';
 import { PanelHeader, UndoToast } from './ui';
 import { PhotoPrivacyDialog } from './PhotoPrivacyDialog';
 import { STORAGE_KEYS, VALIDATION } from '../constants';
@@ -56,8 +57,10 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
     const editAmountInputRef = useRef<HTMLInputElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const popoverRef = useRef<HTMLDivElement>(null);
+    const listRef = useRef<HTMLDivElement>(null);
     const isCancellingRef = useRef(false);
     const identifyAbortRef = useRef<AbortController | null>(null);
+    const rememberRemoval = useRemovalFocus(listRef, nameInputRef, '[data-remove-entry]', pantryItems.length);
 
     const handleTipClick = (item: PantryItem) => {
         if (openTipForId === item.id) {
@@ -70,13 +73,37 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
         }
     };
 
+    // Closing from inside the popover — Escape, or its own close button —
+    // unmounts whatever had focus, so hand it back to the icon that opened it
+    // rather than letting it fall to <body>. An outside click keeps using the
+    // plain setter: the pointer has already chosen where it is going.
+    const closeTip = useCallback(() => {
+        if (!openTipForId) return;
+        const trigger = document.querySelector<HTMLElement>(
+            `[data-storage-tip-trigger="${CSS.escape(openTipForId)}"]`
+        );
+        setOpenTipForId(null);
+        trigger?.focus();
+    }, [openTipForId]);
+
+    useEffect(() => {
+        if (!openTipForId) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key !== 'Escape') return;
+            e.stopPropagation();
+            closeTip();
+        };
+        document.addEventListener('keydown', handler);
+        return () => document.removeEventListener('keydown', handler);
+    }, [openTipForId, closeTip]);
+
     useEffect(() => {
         if (!openTipForId) return;
         const handler = (e: MouseEvent) => {
             const target = e.target as Element | null;
             if (!target) return;
             if (popoverRef.current?.contains(target)) return;
-            if (target.closest('[data-storage-tip-trigger="true"]')) return;
+            if (target.closest('[data-storage-tip-trigger]')) return;
             setOpenTipForId(null);
         };
         document.addEventListener('mousedown', handler);
@@ -333,7 +360,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                         </div>
                     </form>
 
-                    <div className="grid grid-cols-1 gap-2 mt-2">
+                    <div ref={listRef} className="grid grid-cols-1 gap-2 mt-2">
                         {pantryItems.length === 0 && (
                             notification?.anchor === 'pantry' ? (
                                 <UndoToast notification={notification} />
@@ -343,7 +370,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                 </div>
                             )
                         )}
-                        {pantryItems.map((item) => {
+                        {pantryItems.map((item, index) => {
                             const cachedTip = tipsActive ? getTip(item.name) : undefined;
                             const tipLoading = tipsActive && isTipLoading(item.name);
                             const tipError = tipsActive ? getTipError(item.name) : undefined;
@@ -355,7 +382,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                         <div className="relative">
                                             <button
                                                 type="button"
-                                                data-storage-tip-trigger="true"
+                                                data-storage-tip-trigger={item.id}
                                                 onClick={() => handleTipClick(item)}
                                                 className={`w-6 h-6 flex items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10 ${cachedTip ? 'ring-2 ring-primary/40' : ''}`}
                                                 aria-label={`${t.storageTips.iconAriaLabel}: ${item.name}`}
@@ -380,7 +407,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                                         </span>
                                                         <button
                                                             type="button"
-                                                            onClick={() => setOpenTipForId(null)}
+                                                            onClick={closeTip}
                                                             className="text-text-muted hover:text-primary transition-colors p-0.5 rounded-full"
                                                             aria-label={t.storageTips.close}
                                                         >
@@ -429,7 +456,8 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                 </div>
                                 <button
                                     type="button"
-                                    onClick={() => onRemovePantryItem(item.id)}
+                                    data-remove-entry
+                                    onClick={() => { rememberRemoval(index); onRemovePantryItem(item.id); }}
                                     className="text-red-500 hover:text-red-600 hover:bg-red-500/10 rounded-full p-1.5 transition-colors"
                                     aria-label={`${t.remove}: ${item.name}`}
                                 >
@@ -442,7 +470,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                             <div className="flex justify-end mt-2">
                                 <button
                                     type="button"
-                                    onClick={onEmptyPantry}
+                                    onClick={() => { rememberRemoval(0); onEmptyPantry(); }}
                                     className="text-sm text-text-muted hover:text-red-500 hover:bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5 cursor-pointer"
                                 >
                                     <Trash2 size={14} />

--- a/src/components/SpiceRack.tsx
+++ b/src/components/SpiceRack.tsx
@@ -1,7 +1,8 @@
-import React, { useState, forwardRef, useImperativeHandle } from 'react';
+import React, { useState, useRef, forwardRef, useImperativeHandle } from 'react';
 import { Plus, Trash2, Leaf } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { PanelHeader } from './ui';
+import { useRemovalFocus } from '../hooks/useRemovalFocus';
 import { VALIDATION } from '../constants';
 
 export interface SpiceRackRef {
@@ -25,6 +26,9 @@ export const SpiceRack = forwardRef<SpiceRackRef, SpiceRackProps>(({
 }, ref) => {
     const { t } = useSettings();
     const [newSpice, setNewSpice] = useState('');
+    const listRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const rememberRemoval = useRemovalFocus(listRef, inputRef, '[data-remove-entry]', spices.length);
 
     const flushPendingInput = (): string | null => {
         const trimmedSpice = newSpice.trim();
@@ -61,6 +65,7 @@ export const SpiceRack = forwardRef<SpiceRackRef, SpiceRackProps>(({
                 <>
                     <form onSubmit={handleSubmit} className="flex flex-col gap-3">
                         <input
+                            ref={inputRef}
                             type="text"
                             placeholder={t.spicesPlaceholder}
                             value={newSpice}
@@ -74,19 +79,20 @@ export const SpiceRack = forwardRef<SpiceRackRef, SpiceRackProps>(({
                         </button>
                     </form>
 
-                    <div className="flex flex-wrap gap-2 mt-2">
+                    <div ref={listRef} className="flex flex-wrap gap-2 mt-2">
                         {spices.length === 0 && (
                             <div className="text-text-muted text-center py-4 italic w-full">
                                 {t.noSpices}
                             </div>
                         )}
 
-                        {spices.map((spice) => (
+                        {spices.map((spice, index) => (
                             <div key={spice} className="flex flex-row items-center gap-1 px-2 py-0.5 rounded-full border border-border-base bg-bg-surface shadow-sm hover:border-border-hover transition-colors">
                                 <span className="font-medium text-xs text-text-main">{spice}</span>
                                 <button
                                     type="button"
-                                    onClick={() => onRemoveSpice(spice)}
+                                    data-remove-entry
+                                    onClick={() => { rememberRemoval(index); onRemoveSpice(spice); }}
                                     className="text-red-500 hover:text-red-600 hover:bg-red-500/10 rounded-full p-0.5 transition-colors"
                                     aria-label={`${t.remove}: ${spice}`}
                                 >

--- a/src/hooks/useRemovalFocus.ts
+++ b/src/hooks/useRemovalFocus.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Keeps the keyboard somewhere sensible after a list entry is removed.
+ *
+ * Removing an entry unmounts the button that was just pressed, and the browser
+ * drops focus on <body>. The keyboard then has no place in the document, so
+ * deleting a second entry means travelling back down from the top — which is
+ * what makes a long list expensive to prune (Rule 6: a deletion the keyboard
+ * cannot recover from is worse than a slow one).
+ *
+ * Call the returned function with the index being removed, in the same handler
+ * that removes it. The effect runs on the next change to `count`, by which
+ * point the list has re-rendered: focus goes to whatever now sits at that
+ * index, to the new last entry if the removed one was last, or to
+ * `fallbackRef` when nothing is left.
+ *
+ * A pending index is always consumed by the next length change, and acted on
+ * only when the list actually got shorter — so a removal that turns out to be
+ * a no-op cannot strand a stale index and steal focus from a later addition.
+ */
+export const useRemovalFocus = (
+    listRef: React.RefObject<HTMLElement | null>,
+    fallbackRef: React.RefObject<HTMLElement | null>,
+    selector: string,
+    count: number,
+) => {
+    const pendingIndexRef = useRef<number | null>(null);
+    const previousCountRef = useRef(count);
+
+    useEffect(() => {
+        const shrank = count < previousCountRef.current;
+        previousCountRef.current = count;
+        const index = pendingIndexRef.current;
+        pendingIndexRef.current = null;
+        if (index === null || !shrank) return;
+
+        const targets = listRef.current?.querySelectorAll<HTMLElement>(selector);
+        if (!targets || targets.length === 0) {
+            fallbackRef.current?.focus();
+            return;
+        }
+        targets[Math.min(index, targets.length - 1)]?.focus();
+    }, [count, listRef, fallbackRef, selector]);
+
+    return useCallback((index: number) => {
+        pendingIndexRef.current = index;
+    }, []);
+};


### PR DESCRIPTION
## What

The two leftovers from #294 that survived the analysis in [this comment](https://github.com/DrDonik/ai-recipe-planner/issues/294#issuecomment-5218780719). Both are the same bug in different clothes: an element that holds focus is unmounted by the very action it performs, and the browser drops focus on `<body>`.

Removing a list entry unmounts the remove button that was just pressed. Deleting a second entry then means travelling back down from the top of the document, and a screen reader is left with no place in the page. That is what actually makes a long list expensive to prune by keyboard — more so than the tab-stop count the issue originally measured.

The storage-tip popover had the same shape of bug **and** no Escape handler at all. The only ways out were an outside click and its own close button, both of which unmount the element holding focus.

## Design & UX

Nothing changes visually, and nothing changes for pointer users.

**Where focus goes after a removal.** To whatever now sits at the removed entry's index — so deleting three entries in a row is three presses in the same place, which is how someone prunes a list. If the removed entry was last, focus goes to the new last entry; if the list is now empty, to that panel's add field. Never to `body` (Rule 6: a deletion the keyboard cannot recover from is worse than a slow one).

**Emptying the pantry** goes through the same path — the button pressed sits inside the list it clears, so it vanishes with it — and lands on the ingredient field. The alternative was focusing the undo toast's button, which is the more tempting Rule 6 answer since the reversal is right there. Rejected: the toast times out after 5s and would strand focus on `body` again, recreating the bug this PR fixes. The toast is `role="alert"` with `aria-live="assertive"`, so it is announced regardless of focus, and it sits after the input in the DOM, so Tab reaches it.

**Popover close.** Escape closes it, and both inside-close paths (Escape, the X button) hand focus back to the icon that opened it. An outside click deliberately keeps the plain setter — the pointer has already chosen where it is going, and moving focus behind it would be a surprise (Rule 7).

## Details

New hook `src/hooks/useRemovalFocus.ts`, used by all three lists. It hangs off the list length rather than a state flip: the effect fires on the next length change, and only acts when the list actually got shorter. That way a removal that turns out to be a no-op cannot strand a pending index and steal focus from a later addition. Doing it with a `useState` flag instead trips `react-hooks/set-state-in-effect`, and rightly so.

Focus targets are found by a `data-remove-entry` attribute on each remove button rather than a ref array, so the indices cannot drift out of sync with the rendered list.

`data-storage-tip-trigger` changes from the literal `"true"` to the item's id, so the close handler can find the trigger it needs to focus. The outside-click matcher now tests for the attribute's presence instead of its value.

No migration, no persistence change, no prompt change, no new network targets, no new strings.

## Testing

`npm run lint` and `npm run build` pass — re-run after the rebase onto `main`, so against the dev-dependency bumps from #299 as well.

Ten scenarios driven in Chromium against the dev server, asserting on `document.activeElement` after each action:

| Scenario | Focus lands on |
|---|---|
| Spice removed from the middle | the spice that took its place |
| Last spice removed | the new last spice |
| Every spice removed one by one | the add field |
| Pantry row removed from the middle | the next row's remove button |
| Last appliance removed | the new last appliance |
| Empty Pantry pressed | the ingredient field |
| Tip popover, Escape | closed, focus back on the tip icon |
| Tip popover, X button | closed, focus back on the tip icon |

All ten pass; `body` is reached in none of them. The popover cases run with a seeded API key, since the tip icon only renders when one is present — the key is never used, the fetch fails, and the popover still opens and closes, which is what is under test.

The browser scenarios were run before the rebase; lint and build were re-run after it.

The test script was written for this verification and removed again rather than left in the tree; the repo has no test harness to add it to.

---

- [x] New strings added to all four languages (en, de, es, fr) — n/a, no new strings
- [x] New panels are collapsible, state persisted to localStorage — n/a, no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.12.4

Refs #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved keyboard focus management when removing kitchen appliances, pantry items, or spices.
  - Focus now moves to the next available item, the last remaining item, or the relevant input when lists become empty.
  - Pantry storage tips can be closed with Escape, with focus restored to the triggering control.

- **Chores**
  - Updated the application version to 1.12.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->