### PR TITLE
One word for cancelling in both switch-off dialogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.13.0
+**Current version**: 1.13.1
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ClearApiKeyDialog.tsx
+++ b/src/components/ClearApiKeyDialog.tsx
@@ -77,7 +77,7 @@ export const ClearApiKeyDialog = ({
                             onClick={onCancel}
                             className="btn btn-quiet w-full py-3 rounded-xl"
                         >
-                            {t.clearApiKey.cancel}
+                            {t.cancel}
                         </button>
                     )}
                 </div>

--- a/src/components/GistSyncDialog.tsx
+++ b/src/components/GistSyncDialog.tsx
@@ -295,7 +295,7 @@ export const GistSyncDialog = ({
                     disabled={busy}
                     className="btn btn-quiet w-full py-2 rounded-xl"
                 >
-                    {t.sync.close}
+                    {t.cancel}
                 </button>
             </div>
         </>
@@ -361,7 +361,7 @@ export const GistSyncDialog = ({
                         onClick={onClose}
                         className="btn btn-quiet w-full py-3 rounded-xl"
                     >
-                        {t.sync.close}
+                        {t.cancel}
                     </button>
                 </div>
             </>

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -290,7 +290,6 @@ export const translations = {
             disableDescription: "Recipes will be prepared for copy & paste from now on. Your API key stays in this browser unless you delete it here.",
             disableAndClear: "Switch off and delete key",
             disableAndKeep: "Switch off and keep key",
-            cancel: "Cancel"
         },
         undo: {
             pantryEmptied: "Pantry emptied",
@@ -355,7 +354,6 @@ export const translations = {
             storedClear: "Delete token",
             storedKeep: "Keep token",
             tokenStoredWarning: "GitHub token stored in local storage",
-            close: "Close",
             pulledNotification: "Synced from another device",
             errorUnauthorized: "Sync error: token is unauthorized or revoked. Please update it.",
             errorNotFound: "Sync error: the Gist was not found. It may have been deleted on GitHub.",
@@ -652,7 +650,6 @@ export const translations = {
             disableDescription: "Rezepte werden ab jetzt zum Kopieren und Einfügen vorbereitet. Dein API-Schlüssel bleibt in diesem Browser gespeichert, sofern du ihn hier nicht löschst.",
             disableAndClear: "Ausschalten und Schlüssel löschen",
             disableAndKeep: "Ausschalten und Schlüssel behalten",
-            cancel: "Abbrechen"
         },
         undo: {
             pantryEmptied: "Vorrat geleert",
@@ -717,7 +714,6 @@ export const translations = {
             storedClear: "Token löschen",
             storedKeep: "Token behalten",
             tokenStoredWarning: "GitHub-Token im lokalen Speicher gespeichert",
-            close: "Schließen",
             pulledNotification: "Von anderem Gerät synchronisiert",
             errorUnauthorized: "Sync-Fehler: Token ist ungültig oder widerrufen. Bitte aktualisieren.",
             errorNotFound: "Sync-Fehler: Der Gist wurde nicht gefunden. Er wurde möglicherweise auf GitHub gelöscht.",
@@ -1014,7 +1010,6 @@ export const translations = {
             disableDescription: "Les recettes seront désormais préparées pour le copier-coller. Votre clé API reste dans ce navigateur, sauf si vous la supprimez ici.",
             disableAndClear: "Désactiver et supprimer la clé",
             disableAndKeep: "Désactiver et conserver la clé",
-            cancel: "Annuler"
         },
         undo: {
             pantryEmptied: "Garde-manger vidé",
@@ -1079,7 +1074,6 @@ export const translations = {
             storedClear: "Supprimer le jeton",
             storedKeep: "Conserver le jeton",
             tokenStoredWarning: "Jeton GitHub stocké dans le stockage local",
-            close: "Fermer",
             pulledNotification: "Synchronisé depuis un autre appareil",
             errorUnauthorized: "Erreur de synchronisation : jeton invalide ou révoqué. Veuillez le mettre à jour.",
             errorNotFound: "Erreur de synchronisation : Gist introuvable. Il a peut-être été supprimé sur GitHub.",
@@ -1376,7 +1370,6 @@ export const translations = {
             disableDescription: "A partir de ahora las recetas se prepararán para copiar y pegar. Tu clave API permanece en este navegador salvo que la elimines aquí.",
             disableAndClear: "Desactivar y eliminar la clave",
             disableAndKeep: "Desactivar y mantener la clave",
-            cancel: "Cancelar"
         },
         undo: {
             pantryEmptied: "Despensa vaciada",
@@ -1441,7 +1434,6 @@ export const translations = {
             storedClear: "Eliminar token",
             storedKeep: "Mantener token",
             tokenStoredWarning: "Token de GitHub almacenado en almacenamiento local",
-            close: "Cerrar",
             pulledNotification: "Sincronizado desde otro dispositivo",
             errorUnauthorized: "Error de sincronización: token no autorizado o revocado. Por favor actualícelo.",
             errorNotFound: "Error de sincronización: Gist no encontrado. Puede haber sido eliminado en GitHub.",


### PR DESCRIPTION
Follow-up to #305, from testing it.

## What

The two credential dialogs unified in #305 still disagreed on the one button that decides nothing: `ClearApiKeyDialog` said "Cancel" / "Abbrechen", `GistSyncDialog` said "Close" / "Schliessen". Same shape, same position, same outcome, two words.

Both now use the existing top-level `cancel` key, which already carried the right wording in all four languages. The two per-dialog labels it replaces — `clearApiKey.cancel` and `sync.close` — are removed rather than left lying around.

## Design & UX

Rule 1, one term per concept. The neutral exit is the one place the two dialogs were still not saying the same thing, which is exactly the seam #305 set out to close.

The sync dialog's setup step moves onto the same key, so that dialog does not say "Cancel" in one step and "Close" in another. Its warning step already said "Cancel", so all three steps now agree.

## Details

No behavioural change: the handlers, the focus trap and the button roles are untouched. `t.a11y.close` still names the close **X**, which is a different concept — dismissing the dialog chrome rather than answering its question — and keeps its own key.

## Testing

`npm run lint` and `npm run build` pass. Both dialogs were opened in Chromium in English and German, and the last button of each compared:

```
[English]  sync neutral: "Cancel"     key neutral: "Cancel"      match
[German]   sync neutral: "Abbrechen"  key neutral: "Abbrechen"   match
```

---

- [x] New strings added to all four languages (en, de, es, fr) — no new strings; two keys removed, one existing key reused
- [x] New controls: focus visible, reachable by keyboard, state not carried by colour alone — no new controls
- [ ] New panels are collapsible, state persisted to localStorage — no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.13.1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWBaNPqFkfHiXhjQcCUEyw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized cancel button labels across API key and synchronization dialogs.
  * Improved consistency of cancel actions across supported languages.

* **Chores**
  * Updated the application version to 1.13.1.
  * Removed redundant translation entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->