### PR TITLE
Tokenise red, and give the copy dialog a voice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.14.0
+**Current version**: 1.14.1
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/InterfaceDesign.md
+++ b/InterfaceDesign.md
@@ -52,9 +52,12 @@ Every action gets a response, scaled to the weight of the action.
 
 **Here:** an asynchronous operation gets a visually hidden `role="status"`
 region beside its visible indicator, so the spinner is not the only channel —
-generation, the timers and the location search have one (#297). Known gap:
-`CopyPasteDialog` still announces a finished copy only by relabelling the
-button, which is disabled in the same moment. Feedback outranks motion
+generation, the timers and the location search have one (#297), and so does the
+copy in `CopyPasteDialog`, which used to announce a finished copy only by
+relabelling the button it disabled in the same moment (#302). Where an action
+can end two ways, both ends share the region — a copy that succeeded and a copy
+that failed are one concern, and two regions for them would talk over each
+other. Feedback outranks motion
 reduction: under `prefers-reduced-motion` the spinner
 keeps turning at 1.5s, because at several call sites the spinner *is* the
 entire message and a frozen one reads as a hang. `animate-pulse` may stop —
@@ -87,10 +90,19 @@ Make the serious mistake hard to make, and recovery specific when it happens.
 (#289) — `btn-warning` puts data somewhere it can be read, `btn-primary` ends
 an exposure already running, `btn-quiet` changes nothing at all. Clearing an
 API key destroys something and is still green, because it ends the exposure the
-dialog is about. Red is reserved for irreversible loss of user content, which
-is why no dialog currently uses it. Where the emphasised button is the risky
+dialog is about. Where the emphasised button is the risky
 one, no button is a default: `useFocusTrap(onClose, true)` focuses the dialog
 itself and Enter does nothing until the user picks.
+
+**Red says what went wrong or what removes something; it does not fill a
+button.** #289 reserved red for irreversible loss of user content and noted that
+no dialog used it — but thirty call sites already spoke red as error text and as
+the remove affordance, so the reservation could only hold by leaving all thirty
+untokenised. It now holds where it does work: the `danger` tokens carry errors
+and removal, and there is no `-fill` pair for a button label to sit on, so the
+red button that rule forbids cannot be built without adding one deliberately
+(#302). A button that destroys still follows the exposure axis — clearing the
+API key is green because it ends an exposure.
 
 Switching a credential off has one shape wherever it appears (#302, #305). The
 toggle commits nothing; the dialog does, through three exits — delete the

--- a/UniversalDesign.md
+++ b/UniversalDesign.md
@@ -30,6 +30,30 @@ works for the other:
 | `--color-warning-text` | amber as text, or as a meaningful icon |
 | `--color-text-on-warning` | the label on the fill |
 
+Red splits the same way but stops at two rungs, because nothing fills a button
+with it (Rule 5 in @InterfaceDesign.md):
+
+| Token | Role |
+| --- | --- |
+| `--color-danger` | the accent behind tints and borders, and the icon inside a button that already names itself — red as affordance |
+| `--color-danger-text` | red that has to be read: every error message, and an icon that is itself the state |
+
+**The cheap rung is the one that fails.** `text-red-500` reads as *the* red and
+was used for both roles at thirty sites; it measures 3.8:1 on white, which is
+fine for the icon and under the 4.5:1 threshold for all seven places it was
+carrying words (#302). Where a hue serves text and non-text alike, the value
+that satisfies the looser rule will get used for both — so give the stricter
+role its own token rather than trusting the call site to pick.
+
+**Measure a text token where the text actually sits.** Half of this app's error
+messages appear inside a dialog, and the glass over the `bg-black/50` backdrop
+takes roughly two points off every ratio measured against an opaque surface:
+`--color-danger-text` reads 8.0:1 on the pantry card and 5.3:1 in
+`CopyPasteDialog`. The first draft of the token passed on paper at 6.9:1 and
+came out at 4.6:1 there, inside rounding of the threshold. `--color-border-strong`
+carries the same two numbers for the same reason. An opaque-surface ratio is not
+the number to put in a pull request if the component lives on glass.
+
 **A border that identifies a control is not a hairline.** `--color-border-base`
 separates surfaces and measures 1.4:1 against white — fine for that job, far
 under the 3:1 SC 1.4.11 asks of anything marking a control. A button whose only

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.14.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ApiKeyDialog.tsx
+++ b/src/components/ApiKeyDialog.tsx
@@ -132,7 +132,7 @@ export const ApiKeyDialog = ({ step, onAcceptWarning, onSave, onDelete, onCancel
                 </div>
 
                 {fieldError && (
-                    <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+                    <p className="text-sm text-danger-text" role="alert">
                         {fieldError}
                     </p>
                 )}

--- a/src/components/CopyPasteDialog.tsx
+++ b/src/components/CopyPasteDialog.tsx
@@ -24,6 +24,11 @@ export const CopyPasteDialog: React.FC<CopyPasteDialogProps> = ({
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const dialogRef = useFocusTrap(onCancel);
 
+    // Both outcomes of the button the user just pressed, so they share one
+    // region rather than competing. Derived while rendering, never pushed on a
+    // transition, and the error keeps its visible text below either step.
+    const announcement = error ?? (copied ? t.copyPaste.copied : '');
+
     const handleCopyAndProceed = async () => {
         try {
             await navigator.clipboard.writeText(prompt);
@@ -90,6 +95,11 @@ export const CopyPasteDialog: React.FC<CopyPasteDialogProps> = ({
                     </button>
                 </div>
 
+                {/* Outside the step switch, so the region outlives the content
+                    it describes — one mounted alongside its first message is
+                    announced by almost no screen reader. */}
+                <p className="sr-only" role="status">{announcement}</p>
+
                 {/* Content */}
                 <div className="flex-1 overflow-y-auto p-3 min-h-0 flex flex-col gap-2">
                     {step === 'copy' ? (
@@ -108,11 +118,7 @@ export const CopyPasteDialog: React.FC<CopyPasteDialogProps> = ({
                                 </pre>
                             </div>
                             {error && (
-                                <div
-                                    role="alert"
-                                    aria-live="assertive"
-                                    className="flex items-center gap-2 text-sm text-red-500"
-                                >
+                                <div className="flex items-center gap-2 text-sm text-danger-text">
                                     <AlertCircle size={16} className="shrink-0" />
                                     <span>{error}</span>
                                 </div>
@@ -146,11 +152,7 @@ export const CopyPasteDialog: React.FC<CopyPasteDialogProps> = ({
                                 className="w-full flex-1 bg-white/30 dark:bg-black/20 rounded-lg p-3 text-sm font-mono resize-none"
                             />
                             {error && (
-                                <div
-                                    role="alert"
-                                    aria-live="assertive"
-                                    className="flex items-center gap-2 text-sm text-red-500"
-                                >
+                                <div className="flex items-center gap-2 text-sm text-danger-text">
                                     <AlertCircle size={16} />
                                     <span>{error}</span>
                                 </div>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -40,8 +40,8 @@ export class ErrorBoundary extends Component<Props, State> {
             return (
                 <div className="min-h-screen bg-bg-app flex items-center justify-center p-8">
                     <div className="glass-panel p-8 max-w-md w-full text-center">
-                        <div className="bg-red-500/10 p-4 rounded-full w-fit mx-auto mb-4">
-                            <AlertTriangle size={48} className="text-red-500" />
+                        <div className="bg-danger/10 p-4 rounded-full w-fit mx-auto mb-4">
+                            <AlertTriangle size={48} className="text-danger-text" />
                         </div>
                         <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
                         <p className="text-text-muted mb-6">
@@ -52,7 +52,7 @@ export class ErrorBoundary extends Component<Props, State> {
                                 <summary className="cursor-pointer text-sm font-medium text-text-muted">
                                     Error details
                                 </summary>
-                                <div className="mt-2 text-xs overflow-auto text-red-600 dark:text-red-400 space-y-2">
+                                <div className="mt-2 text-xs overflow-auto text-danger-text space-y-2">
                                     <div>
                                         <strong>Message:</strong>
                                         <pre className="mt-1">{this.state.error.message}</pre>

--- a/src/components/GistSyncDialog.tsx
+++ b/src/components/GistSyncDialog.tsx
@@ -269,7 +269,7 @@ export const GistSyncDialog = ({
                 </div>
 
                 {fieldError && (
-                    <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+                    <p className="text-sm text-danger-text" role="alert">
                         {fieldError}
                     </p>
                 )}
@@ -333,8 +333,8 @@ export const GistSyncDialog = ({
                 </div>
 
                 {errorMessage && (
-                    <div className="mb-4 bg-red-500/10 border border-red-500/30 rounded-lg p-3">
-                        <p className="text-sm text-red-700 dark:text-red-400">{errorMessage}</p>
+                    <div className="mb-4 bg-danger/10 border border-danger/30 rounded-lg p-3">
+                        <p className="text-sm text-danger-text">{errorMessage}</p>
                     </div>
                 )}
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -61,7 +61,7 @@ export const Header: React.FC<HeaderProps> = ({
             case 'synced':
                 return <Cloud size={16} className="text-primary" />;
             case 'error':
-                return <Cloud size={16} className="text-red-500" />;
+                return <Cloud size={16} className="text-danger-text" />;
             case 'idle':
             default:
                 return <CloudOff size={16} className="text-text-muted" />;
@@ -259,7 +259,7 @@ export const Header: React.FC<HeaderProps> = ({
                             indicator above stays hidden. */}
                         {headerMinimized && syncKeptOff && (
                             <TooltipButton
-                                icon={<AlertTriangle size={16} className="text-red-500" />}
+                                icon={<AlertTriangle size={16} className="text-danger-text" />}
                                 tooltip={t.sync.tokenStoredWarning}
                                 ariaLabel={t.sync.tokenStoredWarning}
                                 className="!p-1 cursor-pointer hover:opacity-80 transition-opacity"
@@ -340,7 +340,7 @@ export const Header: React.FC<HeaderProps> = ({
                                     trailing={
                                         syncKeptOff ? (
                                             <TooltipButton
-                                                icon={<AlertTriangle size={16} className="text-red-500" />}
+                                                icon={<AlertTriangle size={16} className="text-danger-text" />}
                                                 tooltip={t.sync.tokenStoredWarning}
                                                 ariaLabel={t.sync.tokenStoredWarning}
                                                 className="!p-1 cursor-pointer hover:opacity-80 transition-opacity"

--- a/src/components/KitchenAppliances.tsx
+++ b/src/components/KitchenAppliances.tsx
@@ -93,7 +93,7 @@ export const KitchenAppliances = forwardRef<KitchenAppliancesRef, KitchenApplian
                                     type="button"
                                     data-remove-entry
                                     onClick={() => { rememberRemoval(index); onRemoveAppliance(appliance); }}
-                                    className="text-red-500 hover:text-red-600 hover:bg-red-500/10 rounded-full p-0.5 transition-colors"
+                                    className="text-danger hover:text-danger-text hover:bg-danger/10 rounded-full p-0.5 transition-colors"
                                     aria-label={`${t.remove}: ${appliance}`}
                                 >
                                     <Trash2 size={10} />

--- a/src/components/KitchenSwitcher.tsx
+++ b/src/components/KitchenSwitcher.tsx
@@ -139,7 +139,7 @@ const LocationField: React.FC<LocationFieldProps> = ({ kitchen, onSelect, onClea
                 alongside its first message is announced by almost no screen
                 reader. `sr-only` is absolutely positioned and so costs this
                 flex column no gap while empty. */}
-            <p className="sr-only" aria-live="polite">{liveStatus}</p>
+            <p className="sr-only" role="status">{liveStatus}</p>
 
             {current && !current.done && <p className="text-xs text-text-muted">{t.kitchen.locationSearching}</p>}
             {current?.done && suggestions.length === 0 && (
@@ -389,7 +389,7 @@ export const KitchenSwitcher: React.FC<KitchenSwitcherProps> = ({
                                                     onDelete(kitchen.id);
                                                     closePopover();
                                                 }}
-                                                className="px-2 py-1 text-xs font-semibold rounded-md bg-red-500/10 text-red-500 hover:bg-red-500/20 whitespace-nowrap"
+                                                className="px-2 py-1 text-xs font-semibold rounded-md bg-danger/10 text-danger-text hover:bg-danger/20 whitespace-nowrap"
                                             >
                                                 {t.kitchen.confirmDelete}
                                             </button>
@@ -407,7 +407,7 @@ export const KitchenSwitcher: React.FC<KitchenSwitcherProps> = ({
                                                     <button
                                                         type="button"
                                                         onClick={() => setConfirmDeleteId(kitchen.id)}
-                                                        className="btn-icon p-1.5 hover:text-red-500"
+                                                        className="btn-icon p-1.5 hover:text-danger"
                                                         aria-label={`${t.kitchen.deleteAria}: ${kitchen.name}`}
                                                     >
                                                         <Trash2 size={14} />

--- a/src/components/PantryInput.tsx
+++ b/src/components/PantryInput.tsx
@@ -339,7 +339,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                 />
                             </div>
                             {identifyError && (
-                                <p role="alert" className="text-sm text-red-500">
+                                <p role="alert" className="text-sm text-danger-text">
                                     {identifyError}
                                 </p>
                             )}
@@ -425,7 +425,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                                             {t.storageTips.loading}
                                                         </p>
                                                     ) : tipError ? (
-                                                        <p className="text-sm text-red-500">{tipError}</p>
+                                                        <p className="text-sm text-danger-text">{tipError}</p>
                                                     ) : null}
                                                 </div>
                                             )}
@@ -461,7 +461,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                     type="button"
                                     data-remove-entry
                                     onClick={() => { rememberRemoval(index); onRemovePantryItem(item.id); }}
-                                    className="text-red-500 hover:text-red-600 hover:bg-red-500/10 rounded-full p-1.5 transition-colors"
+                                    className="text-danger hover:text-danger-text hover:bg-danger/10 rounded-full p-1.5 transition-colors"
                                     aria-label={`${t.remove}: ${item.name}`}
                                 >
                                     <Trash2 size={16} />
@@ -474,7 +474,7 @@ export const PantryInput = forwardRef<PantryInputRef, PantryInputProps>(({
                                 <button
                                     type="button"
                                     onClick={() => { rememberRemoval(0); onEmptyPantry(); }}
-                                    className="text-sm text-text-muted hover:text-red-500 hover:bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5 cursor-pointer"
+                                    className="text-sm text-text-muted hover:text-danger-text hover:bg-danger/10 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5 cursor-pointer"
                                 >
                                     <Trash2 size={14} />
                                     {t.emptyPantry}

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -211,7 +211,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, index, showOpenI
                     {onDelete && (
                         <button
                             onClick={onDelete}
-                            className="p-2 bg-white/50 hover:bg-red-100 dark:bg-black/20 dark:hover:bg-red-900/30 rounded-full transition-colors flex items-center justify-center text-red-400 hover:text-red-500"
+                            className="p-2 bg-white/50 hover:bg-danger/10 dark:bg-black/20 dark:hover:bg-danger/20 rounded-full transition-colors flex items-center justify-center text-danger hover:text-danger-text"
                             aria-label={t.deleteRecipe}
                         >
                             <Trash2 size={18} />

--- a/src/components/RecipeChat.tsx
+++ b/src/components/RecipeChat.tsx
@@ -217,7 +217,7 @@ export const RecipeChat: React.FC<RecipeChatProps> = ({ recipe, chat }) => {
                                 )}
 
                                 {error && !isPending && (
-                                    <div role="alert" className="flex items-start gap-2 text-xs text-red-500">
+                                    <div role="alert" className="flex items-start gap-2 text-xs text-danger-text">
                                         <AlertCircle size={14} className="shrink-0 mt-0.5" />
                                         <span className="flex-1">{error}</span>
                                         <button

--- a/src/components/ReplaceRecipeDialog.tsx
+++ b/src/components/ReplaceRecipeDialog.tsx
@@ -98,7 +98,7 @@ export const ReplaceRecipeDialog: React.FC<ReplaceRecipeDialogProps> = ({
                     )}
 
                     {error && !isLoading && (
-                        <div role="alert" aria-live="assertive" className="flex items-center gap-2 text-sm text-red-500">
+                        <div role="alert" className="flex items-center gap-2 text-sm text-danger-text">
                             <AlertCircle size={16} className="shrink-0" />
                             <span>{error}</span>
                         </div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -161,7 +161,7 @@ export const SettingsPanel = forwardRef<SettingsPanelRef, SettingsPanelProps>(({
                                         <button
                                             type="button"
                                             onClick={() => handleRemoveStyleWish(wish)}
-                                            className="text-red-500 hover:text-red-600 hover:bg-red-500/10 rounded-full p-0.5 transition-colors"
+                                            className="text-danger hover:text-danger-text hover:bg-danger/10 rounded-full p-0.5 transition-colors"
                                             aria-label={t.remove}
                                         >
                                             <Trash2 size={10} />
@@ -211,7 +211,7 @@ export const SettingsPanel = forwardRef<SettingsPanelRef, SettingsPanelProps>(({
                                         <button
                                             type="button"
                                             onClick={() => handleRemovePlannedRecipe(recipe)}
-                                            className="text-red-500 hover:text-red-600 hover:bg-red-500/10 rounded-full p-0.5 transition-colors"
+                                            className="text-danger hover:text-danger-text hover:bg-danger/10 rounded-full p-0.5 transition-colors"
                                             aria-label={t.remove}
                                         >
                                             <Trash2 size={10} />

--- a/src/components/ShoppingList.tsx
+++ b/src/components/ShoppingList.tsx
@@ -252,7 +252,7 @@ export const ShoppingList: React.FC<ShoppingListProps> = ({ items, isMinimized =
                             <button
                                 type="button"
                                 onClick={onClear}
-                                className="text-sm text-text-muted hover:text-red-500 hover:bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5 cursor-pointer"
+                                className="text-sm text-text-muted hover:text-danger-text hover:bg-danger/10 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5 cursor-pointer"
                             >
                                 <Trash2 size={14} />
                                 {t.clearShoppingList}

--- a/src/components/SpiceRack.tsx
+++ b/src/components/SpiceRack.tsx
@@ -93,7 +93,7 @@ export const SpiceRack = forwardRef<SpiceRackRef, SpiceRackProps>(({
                                     type="button"
                                     data-remove-entry
                                     onClick={() => { rememberRemoval(index); onRemoveSpice(spice); }}
-                                    className="text-red-500 hover:text-red-600 hover:bg-red-500/10 rounded-full p-0.5 transition-colors"
+                                    className="text-danger hover:text-danger-text hover:bg-danger/10 rounded-full p-0.5 transition-colors"
                                     aria-label={`${t.remove}: ${spice}`}
                                 >
                                     <Trash2 size={10} />

--- a/src/components/TimerTray.tsx
+++ b/src/components/TimerTray.tsx
@@ -155,7 +155,7 @@ export const TimerTray: React.FC = () => {
                           type="button"
                           onClick={() => cancelTimer(timer.id)}
                           aria-label={isDone ? t.timers.dismiss : t.timers.cancel}
-                          className="p-1.5 rounded-full transition-colors text-text-muted hover:text-red-500 hover:bg-white/60 dark:hover:bg-black/30"
+                          className="p-1.5 rounded-full transition-colors text-text-muted hover:text-danger hover:bg-white/60 dark:hover:bg-black/30"
                         >
                           <X size={14} />
                         </button>

--- a/src/components/ui/UndoToast.tsx
+++ b/src/components/ui/UndoToast.tsx
@@ -15,7 +15,7 @@ const renderTextWithLinks = (text: string) => {
                     href={part}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="underline hover:text-red-800 transition-colors"
+                    className="underline hover:opacity-80 transition-opacity"
                 >
                     {part}
                 </a>
@@ -28,11 +28,10 @@ const renderTextWithLinks = (text: string) => {
 export const UndoToast = ({ notification }: UndoToastProps) => (
     <div
         role="alert"
-        aria-live="assertive"
         aria-atomic="true"
         className={`p-4 rounded-xl border text-sm animate-in fade-in slide-in-from-top-2 flex items-center justify-between gap-3 ${
             notification.type === 'error'
-                ? 'bg-red-50 text-red-600 border-red-100 dark:bg-red-950/50 dark:text-red-400 dark:border-red-900'
+                ? 'bg-danger/10 text-danger-text border-danger/30'
                 : 'bg-warning/10 text-warning-text border-warning/30'
         }`}
     >
@@ -43,7 +42,7 @@ export const UndoToast = ({ notification }: UndoToastProps) => (
                 aria-label={notification.action.ariaLabel || notification.action.label}
                 className={`px-3 py-1 rounded-lg font-medium text-sm transition-colors shrink-0 ${
                     notification.type === 'error'
-                        ? 'bg-red-100 hover:bg-red-200 dark:bg-red-900 dark:hover:bg-red-800'
+                        ? 'bg-danger/20 hover:bg-danger/30'
                         : 'bg-warning/20 hover:bg-warning/30'
                 }`}
             >

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,12 @@
   --color-warning-text: hsl(28, 90%, 31%);
   --color-text-on-warning: hsl(0, 0%, 100%);
 
+  /* Danger (red), two roles and deliberately no third: the accent that tints
+     surfaces, draws borders and colours the icon inside a named button, and red
+     used as text or as an icon that is itself the message. */
+  --color-danger: hsl(0, 84%, 60%);
+  --color-danger-text: hsl(0, 74%, 36%);
+
   --color-border-base: hsl(240, 5%, 85%);
   --color-border-hover: hsl(240, 5%, 70%);
   --color-border-strong: hsl(240, 4%, 40%);
@@ -73,6 +79,23 @@
      text and as an icon on every surface it lands on, tints included. */
   --hue-warning: 38;
 
+  /* Danger: Red. Two rungs, and no fill pair — #289 reserves red as a button
+     fill for irreversible loss of user content, which nothing in this app does,
+     so declaring one would only invite the red button that rule forbids.
+     --color-danger is the accent: tints, borders, and the icon inside a button
+     that already says what it does in its accessible name, where red is an
+     affordance rather than a state (3.8:1 in light mode, 4.4:1 in dark, against
+     the 3:1 SC 1.4.11 asks of non-text). --color-danger-text is the rung for red
+     that has to be read — every error message, and the icons that carry a state
+     no label repeats — at 8.0:1 on an opaque light surface and 7.0:1 on the
+     danger/10 tint. It sits two rungs below the accent rather than one because
+     half the errors in this app appear inside a dialog, where the glass over the
+     black/50 backdrop costs it most of its headroom: 40% lightness measured
+     6.9:1 opaque but only 4.6:1 there, where 36% still holds 5.3:1.
+     text-red-500 sat at 3.8:1 as text and was under the threshold at seven call
+     sites. */
+  --hue-danger: 0;
+
   /* Light Mode Semantic Colors */
   --color-bg-app: hsl(var(--hue-neutral), 5%, 96%);
   --color-bg-surface: hsl(255, 100%, 100%);
@@ -103,6 +126,9 @@
   --color-warning-fill: hsl(30, 92%, 36%);
   --color-warning-fill-hover: hsl(30, 92%, 30%);
   --color-warning-text: hsl(28, 90%, 31%);
+
+  --color-danger: hsl(var(--hue-danger), 84%, 60%);
+  --color-danger-text: hsl(var(--hue-danger), 74%, 36%);
 
   /* Glass Effects */
   --glass-bg: hsla(0, 0%, 100%, 0.7);
@@ -147,6 +173,10 @@
     --color-warning-fill: hsl(var(--hue-warning), 92%, 50%);
     --color-warning-fill-hover: hsl(var(--hue-warning), 92%, 58%);
     --color-warning-text: hsl(43, 96%, 56%);
+
+    /* The accent holds at 60% — it is already 4.4:1 on the dark surface. Only
+       the text rung moves, up rather than down, exactly as the amber one does. */
+    --color-danger-text: hsl(var(--hue-danger), 90%, 70%);
 
     --glass-bg: hsla(var(--hue-neutral), 5%, 12%, 0.6);
     --glass-border: hsla(var(--hue-neutral), 5%, 80%, 0.08);


### PR DESCRIPTION
## What

Part B of #302, the leftover accessibility gaps. Part A landed in #305 and #307.

#287 replaced every raw amber utility with semantic tokens and left red alone,
so the heavier colour stayed raw Tailwind at thirty call sites with the value
picked per site — `red-400`, `red-500`, `red-600`, `red-700`, and a private scale
of `red-50`/`100`/`950` inside `UndoToast`. `text-red-500` reads as *the* red and
was doing both jobs red has here, which is why seven of those sites were putting
words on a 3.8:1 colour.

Alongside it, the three live-region defects: `CopyPasteDialog` announced a
finished copy only by relabelling the button it disabled in the same moment,
`KitchenSwitcher` used a second spelling of a pattern #297 had just established,
and four regions asked for `aria-live="assertive"` where at most two had any
claim to interrupting.

## Design & UX

**Red splits the way amber does but stops at two rungs** (Rule 1, and the colour
section of UniversalDesign.md). `--color-danger` is the accent behind tints,
borders and the icon inside a button that already names itself — red as
affordance, where 3:1 is the bar. `--color-danger-text` is the rung for red that
has to be read: every error message, and the icons that carry a state no label
repeats, like the sync-error cloud.

**There is deliberately no `-fill` pair** (Rule 5). #289 reserved red as a button
fill for irreversible loss of user content and noted that no dialog used it — but
thirty call sites already spoke red as error text and as the remove affordance,
so that reservation could only hold by leaving all thirty untokenised. It now
holds where it does work: with no fill token to sit a label on, the red button
that rule forbids cannot be built without adding one deliberately. A button that
destroys still follows the exposure axis, which is why clearing the API key stays
green.

**Both outcomes of the copy button share one region** (Rule 3). A copy that
succeeded and a copy that failed are the same concern; two regions for them would
talk over each other. That also decided the assertive question for the copy
errors — they reach the reader through the status region now instead of a
`role="alert"` on the visible text, and nothing about this dialog justifies
interrupting mid-sentence.

## Details

**The text rung sits two steps below the accent, not one.** Half this app's
errors live inside a dialog, and the glass over the `bg-black/50` backdrop takes
roughly two points off every ratio measured against an opaque surface. The first
draft passed on paper at 6.9:1 and came out at 4.6:1 in `CopyPasteDialog`, inside
rounding of the threshold; 36% lightness holds 5.3:1 there. `--color-border-strong`
already carried the same two-number story, so UniversalDesign.md now says plainly
that an opaque-surface ratio is not the number to quote for a component that
lives on glass.

**Two failures the issue had not catalogued.** `RecipeCard`'s delete icon was
`text-red-400` at 2.77:1, under the *non-text* threshold as well, and the
`UndoToast` error variant put `red-600` on `red-50` at 4.41:1. The toast now
mirrors its own warning branch exactly rather than carrying a second scale. Its
link also dropped a hardcoded `hover:text-red-800` that was wrong in the warning
variant it applied to equally.

**No new strings, no persistence changes, no new network targets.** The status
region reuses `t.copyPaste.copied` and the existing error strings.

## Testing

Driven in Chromium against the dev server, light and dark, with the ratios read
off the rendered pixels rather than an assumed background — the dialog is
translucent, so computing them from the token value would have been wrong:

| Pairing | Light | Dark | Needs |
| --- | --- | --- | --- |
| `danger-text` on an opaque surface | 8.0:1 | 5.9:1 | 4.5 |
| `danger-text` on the `danger/10` tint | 7.0:1 | 5.4:1 | 4.5 |
| `danger-text` on composited dialog glass | **5.3:1** | **6.4:1** | 4.5 |
| `danger` as icon, on the pantry surface | 3.8:1 | 4.5:1 | 3.0 |

- Pantry remove button: accent at rest, `danger-text` on hover — darker in light
  mode, lighter in dark, so it advances either way.
- `CopyPasteDialog`: the status region is present and empty before the copy,
  reads "Copied!" after it, and carries the paste-step error verbatim on an empty
  submit. Confirmed the visible error `div` no longer holds `role="alert"` or
  `aria-live`, so there is exactly one announcement.
- Both themes screenshotted with an error showing; no page errors in either.
- `npm run lint` and `npm run build` pass.

Not run: no automated tests exist in this repo. The clipboard *failure* path was
not forced — the paste-step error was used to exercise the same region.

---

- [x] New strings added to all four languages (en, de, es, fr) — accessible names included — n/a, no new strings
- [x] New controls: focus visible, reachable by keyboard, state not carried by colour alone — and new motion checked under `prefers-reduced-motion` — n/a, no new controls or motion; the colours changed under existing ones
- [x] New panels are collapsible, state persisted to localStorage — n/a, no new panels
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.14.1

Closes #302.

---
_Generated by [Claude Code](https://claude.ai/code/session_018BAPrFD7TXTidTMLnD412y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Copy operations now provide consistent screen-reader announcements for success and failure.
  * Status messaging and error alerts use clearer semantic behavior.

* **Visual Improvements**
  * Error, warning, removal, and destructive-action styling now adapts consistently across light and dark themes.
  * Improved danger-text contrast and clearer distinction between accents and readable error text.

* **Documentation**
  * Updated interface and accessibility guidance for status announcements, danger colors, and contrast requirements.

* **Chores**
  * Updated the application version to 1.14.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->