### PR TITLE
feat(header): give the API key its own switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.14.1
+**Current version**: 1.15.0
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.14.1",
+  "version": "1.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ClearApiKeyDialog.tsx
+++ b/src/components/ClearApiKeyDialog.tsx
@@ -8,12 +8,13 @@ interface ClearApiKeyDialogProps {
 }
 
 /**
- * The API key's only destructive exit, reached from the key dialog.
+ * The API key's only destructive exit, reached from the key dialog and from the
+ * key's own switch being turned off.
  *
- * It gates no switch: the key is not tied to a mode any more, so there is no
- * flip to undo and no third outcome to offer. Two exits are the whole question
- * — delete the key (the exposure ends) or keep it (nothing changes), which is
- * also where Escape lands.
+ * It gates that switch, but unlike the sync dialog it still offers two exits
+ * rather than three: a kept key is a key in use, so there is no stored-but-off
+ * state for a "keep it" to move the switch into. Keeping and cancelling are one
+ * outcome — nothing changes — and that is where Escape lands.
  */
 export const ClearApiKeyDialog = ({ onClear, onKeep }: ClearApiKeyDialogProps) => {
     const { t } = useSettings();

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, Info } from 'lucide-react';
+import { Utensils, Key, Globe, ChevronUp, ChevronDown, CircleHelp, AlertTriangle, Download, Upload, Cloud, CloudOff, Loader2, Info, Sparkles, Pencil } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { STORAGE_KEYS } from '../constants';
 import { ApiKeyDialog, type ApiKeyDialogStep } from './ApiKeyDialog';
@@ -47,8 +47,9 @@ export const Header: React.FC<HeaderProps> = ({
     const importFileRef = useRef<HTMLInputElement>(null);
 
     // Sync config as stored on this device, read at render because every path
-    // that changes it reloads the page. `syncKeptOff` is the counterpart of a
-    // stored API key in Copy & Paste mode: the credential outlived the feature.
+    // that changes it reloads the page. `syncKeptOff` is a token that outlived
+    // the feature it was entered for — the state the API key no longer has,
+    // which is why only sync's switch-off asks a third question.
     const syncKeptOff = readStoredSyncConfig() !== null && !isSyncEnabled();
 
     const syncIcon = (() => {
@@ -159,6 +160,20 @@ export const Header: React.FC<HeaderProps> = ({
         // collects it, behind the storage warning on first use.
         if (apiKey) {
             setUseCopyPaste(false);
+            return;
+        }
+        setApiDialogStep(hasSeenApiKeyWarning() ? 'key' : 'warning');
+    };
+
+    const handleApiKeyToggle = () => {
+        // The one switch that owns the key, so it is allowed to gate it. Both
+        // directions open a dialog and neither commits here: switching on, the
+        // key dialog stores the key (behind the storage warning on first use);
+        // switching off, ClearApiKeyDialog decides. Unlike sync there is no
+        // third exit, because a key kept is a key in use — the switch has no
+        // stored-but-off state to land in.
+        if (apiKey) {
+            setShowClearDialog(true);
             return;
         }
         setApiDialogStep(hasSeenApiKeyWarning() ? 'key' : 'warning');
@@ -295,7 +310,7 @@ export const Header: React.FC<HeaderProps> = ({
                                 and trailing affordance line up across all rows. */}
                             <div className="grid grid-cols-[auto_auto_auto_auto] items-center gap-x-2 gap-y-3 animate-in fade-in slide-in-from-top-2 duration-300">
                                 <Toggle
-                                    icon={<Key size={14} />}
+                                    icon={<Sparkles size={14} />}
                                     label={t.modeSwitch.label}
                                     checked={!useCopyPaste}
                                     onChange={handleModeToggle}
@@ -303,14 +318,34 @@ export const Header: React.FC<HeaderProps> = ({
                                        without a key. Every other flip commits on
                                        the spot, in both directions. */
                                     opensDialog={useCopyPaste && !apiKey}
-                                    /* The key's own control, and independent of
-                                       the mode: with a key stored it is what the
-                                       other four capabilities run on, so it stays
-                                       reachable in Copy & Paste too. */
+                                    trailing={
+                                        <TooltipButton
+                                            icon={<Info size={14} className="text-text-muted" />}
+                                            tooltip={t.modeSwitch.tooltip}
+                                            ariaLabel={`${t.a11y.info}: ${t.modeSwitch.label}`}
+                                            className="!p-1"
+                                        />
+                                    }
+                                />
+
+                                {/* The key is a stored credential like the Gist
+                                    token, so it gets the same shape: a switch that
+                                    is on exactly when the key is stored, and reads
+                                    as one at a glance rather than as an icon that
+                                    happens to be clickable. Independent of the
+                                    mode — with a key stored it is what photo
+                                    recognition, tips, images, replacement and chat
+                                    run on, in Copy & Paste too. */}
+                                <Toggle
+                                    icon={<Key size={14} />}
+                                    label={t.apiKeyDialog.heading}
+                                    checked={!!apiKey}
+                                    onChange={handleApiKeyToggle}
+                                    opensDialog
                                     trailing={
                                         apiKey ? (
                                             <TooltipButton
-                                                icon={<Key size={14} className="text-text-muted" />}
+                                                icon={<Pencil size={14} className="text-text-muted" />}
                                                 tooltip={t.apiKeyDialog.editTooltip}
                                                 ariaLabel={t.apiKeyDialog.editTooltip}
                                                 className="!p-1 cursor-pointer hover:opacity-80 transition-opacity"
@@ -319,8 +354,8 @@ export const Header: React.FC<HeaderProps> = ({
                                         ) : (
                                             <TooltipButton
                                                 icon={<Info size={14} className="text-text-muted" />}
-                                                tooltip={t.modeSwitch.tooltip}
-                                                ariaLabel={`${t.a11y.info}: ${t.modeSwitch.label}`}
+                                                tooltip={t.apiKeyDialog.tooltip}
+                                                ariaLabel={`${t.a11y.info}: ${t.apiKeyDialog.heading}`}
                                                 className="!p-1"
                                             />
                                         )

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -232,7 +232,7 @@ export const translations = {
         },
         modeSwitch: {
             label: "Generate directly",
-            tooltip: "Off: the meal-plan prompt is prepared for any AI chat. On: the meal plan is generated directly with your stored Gemini API key. Photo recognition, storage tips, recipe images, single-recipe replacement and the cooking chat run on the key either way."
+            tooltip: "Off: the meal-plan prompt is prepared for any AI chat. On: the meal plan is generated directly with your stored Gemini API key."
         },
         storageTips: {
             iconAriaLabel: "Storage tip",
@@ -280,7 +280,8 @@ export const translations = {
             save: "Save key",
             delete: "Delete key",
             errorEmpty: "Please enter an API key.",
-            editTooltip: "Change API key"
+            editTooltip: "Change API key",
+            tooltip: "Off: no key is stored, and meal plans are prepared for copy & paste. On: the key is stored in this browser and enables direct generation, photo recognition, storage tips, recipe images, single-recipe replacement and the cooking chat."
         },
         clearApiKey: {
             title: "Clear API Key?",
@@ -587,7 +588,7 @@ export const translations = {
         },
         modeSwitch: {
             label: "Direkt generieren",
-            tooltip: "Aus: der Prompt für den Menüplan wird für einen beliebigen KI-Chat vorbereitet. An: der Menüplan wird direkt mit deinem gespeicherten Gemini-API-Schlüssel erzeugt. Fotoerkennung, Lagerungstipps, Rezeptbilder, das Ersetzen einzelner Rezepte und der Kochchat laufen so oder so über den Schlüssel."
+            tooltip: "Aus: der Prompt für den Menüplan wird für einen beliebigen KI-Chat vorbereitet. An: der Menüplan wird direkt mit deinem gespeicherten Gemini-API-Schlüssel erzeugt."
         },
         storageTips: {
             iconAriaLabel: "Lagerungstipp",
@@ -635,7 +636,8 @@ export const translations = {
             save: "Schlüssel speichern",
             delete: "Schlüssel löschen",
             errorEmpty: "Bitte gib einen API-Schlüssel ein.",
-            editTooltip: "API-Schlüssel ändern"
+            editTooltip: "API-Schlüssel ändern",
+            tooltip: "Aus: es ist kein Schlüssel gespeichert, und Menüpläne werden zum Kopieren & Einfügen vorbereitet. An: der Schlüssel wird in diesem Browser gespeichert und ermöglicht direktes Generieren, Fotoerkennung, Lagerungstipps, Rezeptbilder, das Ersetzen einzelner Rezepte und den Kochchat."
         },
         clearApiKey: {
             title: "API-Schlüssel löschen?",
@@ -942,7 +944,7 @@ export const translations = {
         },
         modeSwitch: {
             label: "Génération directe",
-            tooltip: "Désactivé : l'invite du plan de repas est préparée pour n'importe quel chat IA. Activé : le plan de repas est généré directement avec votre clé API Gemini stockée. La reconnaissance photo, les conseils de conservation, les images de recettes, le remplacement d'une recette et le chat de cuisine fonctionnent avec la clé dans les deux cas."
+            tooltip: "Désactivé : l'invite du plan de repas est préparée pour n'importe quel chat IA. Activé : le plan de repas est généré directement avec votre clé API Gemini stockée."
         },
         storageTips: {
             iconAriaLabel: "Conseil de conservation",
@@ -990,7 +992,8 @@ export const translations = {
             save: "Enregistrer la clé",
             delete: "Supprimer la clé",
             errorEmpty: "Veuillez saisir une clé API.",
-            editTooltip: "Modifier la clé API"
+            editTooltip: "Modifier la clé API",
+            tooltip: "Désactivé : aucune clé n'est stockée et les plans de repas sont préparés pour le copier-coller. Activé : la clé est stockée dans ce navigateur et permet la génération directe, la reconnaissance photo, les conseils de conservation, les images de recettes, le remplacement d'une recette et le chat de cuisine."
         },
         clearApiKey: {
             title: "Effacer la clé API ?",
@@ -1297,7 +1300,7 @@ export const translations = {
         },
         modeSwitch: {
             label: "Generación directa",
-            tooltip: "Desactivado: el prompt del plan de comidas se prepara para cualquier chat de IA. Activado: el plan de comidas se genera directamente con tu clave API de Gemini almacenada. El reconocimiento de fotos, los consejos de conservación, las imágenes de recetas, el reemplazo de una receta y el chat de cocina funcionan con la clave en ambos casos."
+            tooltip: "Desactivado: el prompt del plan de comidas se prepara para cualquier chat de IA. Activado: el plan de comidas se genera directamente con tu clave API de Gemini almacenada."
         },
         storageTips: {
             iconAriaLabel: "Consejo de conservación",
@@ -1345,7 +1348,8 @@ export const translations = {
             save: "Guardar clave",
             delete: "Eliminar clave",
             errorEmpty: "Introduce una clave API.",
-            editTooltip: "Cambiar la clave API"
+            editTooltip: "Cambiar la clave API",
+            tooltip: "Desactivado: no hay ninguna clave almacenada y los planes de comidas se preparan para copiar y pegar. Activado: la clave se almacena en este navegador y habilita la generación directa, el reconocimiento de fotos, los consejos de conservación, las imágenes de recetas, el reemplazo de una receta y el chat de cocina."
         },
         clearApiKey: {
             title: "¿Eliminar clave API?",


### PR DESCRIPTION
## What

The Gemini API key had no control of its own. It hung off the "Generate directly" row as a trailing icon — muted, borderless, and carrying the same `Key` glyph the row already showed on the left — so a stored key looked much like no key at all, and the only way to enter one was to flip a switch about something else. The header is the single entry point for the key in the whole app; every other consumer (photo recognition, storage tips, images, replacement, chat) reads `apiKey` and never asks for it.

The key now gets the row it should have had, between "Generate directly" and "Device sync". The switch is on exactly when a key is stored — that is the indicator #309 asks for — and the pencil beside it is what changes a stored key.

Closes #309

## Design & UX

**Rule 5 — a switch may not gate a credential it does not own.** #307 took the key away from the route switch for exactly that reason and left the key without a switch at all. This switch *owns* the key, which is the permitted shape, and it is the shape sync already uses: on opens `ApiKeyDialog` (the storage warning first on first use, then the field), off hands the decision to `ClearApiKeyDialog`. Neither direction commits in the handler; the switch moves only when a dialog decides. `aria-haspopup="dialog"` on both.

**Two exits, not three.** The documented switch-off contract has delete / keep / cancel, but sync earns its third exit from a real state — a token kept while sync is off. The key has no stored-but-off state (#307 removed it), so "keep it" and "cancel" are one outcome: nothing changes, and Escape lands there. `ClearApiKeyDialog` is unchanged; only its doc comment, which claimed it gated no switch, is corrected.

**Rule 7 — no dead ends.** "Generate directly" is not disabled when no key is stored; flipping it on still routes through the key dialog, so the existing one-flip path for a new user survives and a second, more obvious path is added beside it. A `disabled` switch would not be focusable and could not carry a tooltip explaining itself.

**Both switches move together**, as they already did: saving a key turns direct generation on, deleting it turns direct generation off with the five-second undo restoring both. The key dialog has always announced this in all four languages ("saving it also switches meal-plan generation over to the API, which you can switch back at any time") — the difference is that both switches now visibly show it instead of one.

**Rule 1 — one term, one treatment.** The route row takes `Sparkles`, the icon the Generate button already uses, so the key glyph names one thing. The trailing affordances keep the sync row's styling; the row label reuses `t.apiKeyDialog.heading`, so the switch and the dialog it opens quote one source and cannot drift apart (SC 2.5.3).

Rejected: leaving the key as a trailing icon and only restyling it as a button. That fixes the affordance but not the indicator — the state would still be "which 14px glyph is this", and a credential would still be the only setting in the header without a switch.

## Details

- `handleApiKeyToggle` is the only new logic (~8 lines). No storage keys, no migration: `checked={!!apiKey}` derives from the value that was always there, so existing users see their stored key as an on switch on first load.
- The on-mount storage warning for pre-existing keys, and the "declined the warning while a key is stored → offer to delete it" path, are untouched.
- `modeSwitch.tooltip` loses its trailing sentence about what else the key powers; that sentence moves, expanded, into the new `apiKeyDialog.tooltip` shown on the key row when no key is stored. Both in all four languages.

## Testing

Driven in Chromium against the dev build. Verified:

- No key, warning seen → key switch opens the key step; saving turns **both** switches on.
- No key, warning not seen → key switch opens the storage warning first; Escape leaves both switches off and does not record the acknowledgement.
- Key stored → key switch opens "Clear API Key?"; Escape leaves both switches on; deleting turns both off; Undo restores both.
- Pencil opens the key dialog for editing; "Generate directly" without a key still opens the key dialog.
- Tab order through the header: `Collapse → Help → Generate directly → Info → Gemini API key → Change API key → Device sync → Sync settings → Language → Export → Import`. Every stop named, ringed, and actionable.
- Layout at 900px and 360px, light and dark, in English, German and French. The longest label ("Gemini-API-Schlüssel") fits the grid at 360px; the page does not scroll horizontally in any of them.
- `npm run lint` and `npm run build` pass.

No new colour pairing — every token on the new row is reused from the sync row, so there is no ratio to report. No new motion: `Toggle` is unchanged and its knob transition is already covered by the global `prefers-reduced-motion` block.

---

- [x] New strings added to all four languages (en, de, es, fr) — accessible names included
- [x] New controls: focus visible, reachable by keyboard, state not carried by colour alone — and new motion checked under `prefers-reduced-motion`
- [ ] New panels are collapsible, state persisted to localStorage — no new panel
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.15.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7Spu281YB99n3M8Z9mPXs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate controls for meal-plan generation mode and saved API key settings.
  * API key controls now indicate whether a key is stored and provide clearer edit, entry, and removal actions.
  * Added updated icons and localized labels in English, German, French, and Spanish.

* **Bug Fixes**
  * Clarified dialog behavior when disabling API key access, including cancel, keep, and Escape outcomes.

* **Documentation**
  * Updated the documented application version to 1.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->