### PR TITLE
fix: keep sync-dialog feedback inside the dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ AI Recipe Planner is a React-based meal planning application that uses AI (Copy-
 
 ## Versioning & Release
 
-**Current version**: 1.16.0
+**Current version**: 1.16.1
 
 This project follows [Semantic Versioning](https://semver.org/) (SemVer):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-recipe-planner",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-recipe-planner",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "dependencies": {
         "framer-motion": "^12.43.0",
         "lucide-react": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-recipe-planner",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.16.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/GistSyncDialog.tsx
+++ b/src/components/GistSyncDialog.tsx
@@ -20,11 +20,12 @@ import type { SyncStatus } from '../hooks/useGistSync';
 /** 'stored' is sync switched off with the token deliberately kept. */
 type Step = 'warning' | 'setup' | 'active' | 'stored';
 
+/** What the dialog has to say about the user's last click. */
+type Notice = { type: 'info' | 'error'; message: string };
+
 interface GistSyncDialogProps {
     onClose: () => void;
     syncStatus: SyncStatus;
-    onShowError: (message: string) => void;
-    onShowInfo: (message: string) => void;
 }
 
 const hasSeenWarning = (): boolean =>
@@ -33,8 +34,6 @@ const hasSeenWarning = (): boolean =>
 export const GistSyncDialog = ({
     onClose,
     syncStatus,
-    onShowError,
-    onShowInfo,
 }: GistSyncDialogProps) => {
     const { t } = useSettings();
     // No button is a safe default in the warning and active steps. The setup
@@ -51,11 +50,11 @@ export const GistSyncDialog = ({
     const [tokenInput, setTokenInput] = useState('');
     const [gistIdInput, setGistIdInput] = useState('');
     const [busy, setBusy] = useState(false);
-    const [fieldError, setFieldError] = useState<string | null>(null);
-    // Dialog-local error for the active step. The global notification toast is
-    // rendered behind the dialog's backdrop, so errors triggered from within
-    // the dialog (e.g. a clipboard failure) must be shown inline.
-    const [copyError, setCopyError] = useState<string | null>(null);
+    // One slot for everything this dialog has to say: the empty-field checks,
+    // the network errors from the setup steps and both ends of the copy button.
+    // The global toast is rendered behind the dialog's backdrop and sits
+    // outside its focus trap, so feedback raised in here has to stay in here.
+    const [notice, setNotice] = useState<Notice | null>(null);
 
     const mapErrorToMessage = (err: unknown): string => {
         if (err instanceof GistUnauthorizedError) return t.sync.errorUnauthorized;
@@ -78,10 +77,10 @@ export const GistSyncDialog = ({
     };
 
     const handleCreateNew = async () => {
-        setFieldError(null);
+        setNotice(null);
         const token = tokenInput.trim();
         if (!token) {
-            setFieldError(t.sync.errorTokenEmpty);
+            setNotice({ type: 'error', message: t.sync.errorTokenEmpty });
             return;
         }
         setBusy(true);
@@ -96,21 +95,21 @@ export const GistSyncDialog = ({
             // Reload so useGistSync initialises with the new config.
             window.location.reload();
         } catch (err) {
-            onShowError(mapErrorToMessage(err));
+            setNotice({ type: 'error', message: mapErrorToMessage(err) });
             setBusy(false);
         }
     };
 
     const handleUseExisting = async () => {
-        setFieldError(null);
+        setNotice(null);
         const token = tokenInput.trim();
         const gistId = gistIdInput.trim();
         if (!token) {
-            setFieldError(t.sync.errorTokenEmpty);
+            setNotice({ type: 'error', message: t.sync.errorTokenEmpty });
             return;
         }
         if (!gistId) {
-            setFieldError(t.sync.errorGistIdEmpty);
+            setNotice({ type: 'error', message: t.sync.errorGistIdEmpty });
             return;
         }
         setBusy(true);
@@ -128,7 +127,7 @@ export const GistSyncDialog = ({
             // and useGistSync initialises with the new config.
             window.location.reload();
         } catch (err) {
-            onShowError(mapErrorToMessage(err));
+            setNotice({ type: 'error', message: mapErrorToMessage(err) });
             setBusy(false);
         }
     };
@@ -157,16 +156,38 @@ export const GistSyncDialog = ({
         if (!initiallyConfigured) return;
         try {
             await navigator.clipboard.writeText(initiallyConfigured.gistId);
-            setCopyError(null);
-            onShowInfo(t.sync.gistIdCopied);
+            setNotice({ type: 'info', message: t.sync.gistIdCopied });
         } catch {
-            // Clipboard failed — surface inline (toasts are hidden by the
-            // dialog backdrop). Reuses the copy-paste translation key since
-            // its wording ("select the text above and copy it manually")
-            // fits the gist-id-above-the-button layout verbatim.
-            setCopyError(t.copyPaste.copyFailed);
+            // Both ends of one button, so they share the slot. The failure
+            // reuses the copy-paste translation key since its wording ("select
+            // the text above and copy it manually") fits the
+            // gist-id-above-the-button layout verbatim.
+            setNotice({ type: 'error', message: t.copyPaste.copyFailed });
         }
     };
+
+    // The sync status only has something to add where sync is configured and
+    // running. `notice` answers the user's last click and therefore outranks
+    // it, which is also why the copy confirmation replaces a standing error.
+    const statusError = step === 'active' && syncStatus === 'error' ? t.sync.errorTooltip : null;
+    const feedback: Notice | null =
+        notice ?? (statusError ? { type: 'error', message: statusError } : null);
+
+    // Carries no role of its own: the permanent region at the foot of the
+    // dialog announces it, and a second role here would say it twice.
+    const noticeBlock = feedback && (
+        <div
+            className={`mb-4 rounded-lg border p-3 ${
+                feedback.type === 'error'
+                    ? 'bg-danger/10 border-danger/30'
+                    : 'bg-warning/10 border-warning/30'
+            }`}
+        >
+            <p className={`text-sm ${feedback.type === 'error' ? 'text-danger-text' : 'text-warning-text'}`}>
+                {feedback.message}
+            </p>
+        </div>
+    );
 
     const renderWarning = () => (
         <>
@@ -267,13 +288,9 @@ export const GistSyncDialog = ({
                         className="w-full px-3 py-2 bg-white/50 dark:bg-black/20 border border-[var(--glass-border)] rounded-lg focus:border-primary text-sm"
                     />
                 </div>
-
-                {fieldError && (
-                    <p className="text-sm text-danger-text" role="alert">
-                        {fieldError}
-                    </p>
-                )}
             </div>
+
+            {noticeBlock}
 
             <div className="flex flex-col gap-3">
                 <button
@@ -303,9 +320,6 @@ export const GistSyncDialog = ({
 
     const renderActive = () => {
         const gistId = initiallyConfigured?.gistId ?? '';
-        // copyError takes precedence — it is a direct response to the user's
-        // last click, while the sync-status error reflects background state.
-        const errorMessage = copyError ?? (syncStatus === 'error' ? t.sync.errorTooltip : null);
         return (
             <>
                 <div className="flex items-center gap-3 mb-4">
@@ -332,11 +346,7 @@ export const GistSyncDialog = ({
                     </div>
                 </div>
 
-                {errorMessage && (
-                    <div className="mb-4 bg-danger/10 border border-danger/30 rounded-lg p-3">
-                        <p className="text-sm text-danger-text">{errorMessage}</p>
-                    </div>
-                )}
+                {noticeBlock}
 
                 <p className="text-sm text-text-muted mb-6">{t.sync.disableNote}</p>
 
@@ -427,6 +437,12 @@ export const GistSyncDialog = ({
                 {step === 'setup' && renderSetup()}
                 {step === 'active' && renderActive()}
                 {step === 'stored' && renderStored()}
+
+                {/* Permanent and outside the steps: a region that appears
+                    together with the text it carries stays silent. One region
+                    for the whole dialog, so a copy that succeeded and a copy
+                    that failed cannot talk over each other. */}
+                <p className="sr-only" role="status">{feedback?.message ?? ''}</p>
             </div>
         </div>
     );

--- a/src/components/GistSyncDialog.tsx
+++ b/src/components/GistSyncDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ShieldAlert, AlertTriangle, ExternalLink, Cloud, Copy, X } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -22,6 +22,9 @@ type Step = 'warning' | 'setup' | 'active' | 'stored';
 
 /** What the dialog has to say about the user's last click. */
 type Notice = { type: 'info' | 'error'; message: string };
+
+/** Lifetime of a confirmation, matching the toast this slot replaced. */
+const NOTICE_TIMEOUT_MS = 3000;
 
 interface GistSyncDialogProps {
     onClose: () => void;
@@ -55,6 +58,32 @@ export const GistSyncDialog = ({
     // The global toast is rendered behind the dialog's backdrop and sits
     // outside its focus trap, so feedback raised in here has to stay in here.
     const [notice, setNotice] = useState<Notice | null>(null);
+    const noticeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    /**
+     * A confirmation is transient — it keeps the three seconds the toast it
+     * replaced had, so a sync error arriving afterwards is not left sitting
+     * behind a stale "copied" for as long as the dialog stays open. An error
+     * has no timeout: it is the more actionable message, and it survives until
+     * the next click, which is what the old `copyError` did.
+     */
+    const showNotice = (next: Notice | null) => {
+        if (noticeTimeoutRef.current) {
+            clearTimeout(noticeTimeoutRef.current);
+            noticeTimeoutRef.current = null;
+        }
+        setNotice(next);
+        if (next?.type === 'info') {
+            noticeTimeoutRef.current = setTimeout(() => {
+                setNotice(null);
+                noticeTimeoutRef.current = null;
+            }, NOTICE_TIMEOUT_MS);
+        }
+    };
+
+    useEffect(() => () => {
+        if (noticeTimeoutRef.current) clearTimeout(noticeTimeoutRef.current);
+    }, []);
 
     const mapErrorToMessage = (err: unknown): string => {
         if (err instanceof GistUnauthorizedError) return t.sync.errorUnauthorized;
@@ -77,10 +106,10 @@ export const GistSyncDialog = ({
     };
 
     const handleCreateNew = async () => {
-        setNotice(null);
+        showNotice(null);
         const token = tokenInput.trim();
         if (!token) {
-            setNotice({ type: 'error', message: t.sync.errorTokenEmpty });
+            showNotice({ type: 'error', message: t.sync.errorTokenEmpty });
             return;
         }
         setBusy(true);
@@ -95,21 +124,21 @@ export const GistSyncDialog = ({
             // Reload so useGistSync initialises with the new config.
             window.location.reload();
         } catch (err) {
-            setNotice({ type: 'error', message: mapErrorToMessage(err) });
+            showNotice({ type: 'error', message: mapErrorToMessage(err) });
             setBusy(false);
         }
     };
 
     const handleUseExisting = async () => {
-        setNotice(null);
+        showNotice(null);
         const token = tokenInput.trim();
         const gistId = gistIdInput.trim();
         if (!token) {
-            setNotice({ type: 'error', message: t.sync.errorTokenEmpty });
+            showNotice({ type: 'error', message: t.sync.errorTokenEmpty });
             return;
         }
         if (!gistId) {
-            setNotice({ type: 'error', message: t.sync.errorGistIdEmpty });
+            showNotice({ type: 'error', message: t.sync.errorGistIdEmpty });
             return;
         }
         setBusy(true);
@@ -127,7 +156,7 @@ export const GistSyncDialog = ({
             // and useGistSync initialises with the new config.
             window.location.reload();
         } catch (err) {
-            setNotice({ type: 'error', message: mapErrorToMessage(err) });
+            showNotice({ type: 'error', message: mapErrorToMessage(err) });
             setBusy(false);
         }
     };
@@ -156,13 +185,13 @@ export const GistSyncDialog = ({
         if (!initiallyConfigured) return;
         try {
             await navigator.clipboard.writeText(initiallyConfigured.gistId);
-            setNotice({ type: 'info', message: t.sync.gistIdCopied });
+            showNotice({ type: 'info', message: t.sync.gistIdCopied });
         } catch {
             // Both ends of one button, so they share the slot. The failure
             // reuses the copy-paste translation key since its wording ("select
             // the text above and copy it manually") fits the
             // gist-id-above-the-button layout verbatim.
-            setNotice({ type: 'error', message: t.copyPaste.copyFailed });
+            showNotice({ type: 'error', message: t.copyPaste.copyFailed });
         }
     };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -515,8 +515,6 @@ export const Header: React.FC<HeaderProps> = ({
             <GistSyncDialog
                 onClose={() => setShowSyncDialog(false)}
                 syncStatus={syncStatus}
-                onShowError={(message) => onShowNotification({ message, type: 'error' })}
-                onShowInfo={(message) => onShowNotification({ message, type: 'undo', timeout: 3000 })}
             />
         )}
         </>


### PR DESCRIPTION
## What

`GistSyncDialog` raised three of its four messages through the global notification toast, which renders in the document flow (max `z-50`, anchored to the panel where the action happened) behind the dialog's `z-[60]` backdrop. Nothing of it reached the user:

- **Copying the Gist ID** confirmed nothing at all. The *failure* path was already worked around inline (`copyError`, with a comment naming exactly this problem), so the two ends of one button used two different channels and the likelier one was silent.
- **"Create new Gist" / "Use existing Gist"** kept the dialog open on failure (`setBusy(false)`) and sent the auth and network errors to the toast. Visible to the user: the button springing back from "Creating…" to its idle label, with no reason given.

Now the dialog carries its own feedback. One `notice` state replaces `fieldError` and `copyError` and takes over both callbacks, so `GistSyncDialog` needs no notification props from `Header` at all — `onShowError` and `onShowInfo` are gone.

## Design & UX

**Why not raise the toast above the backdrop.** Two reasons, and the second is decisive. The toast is anchored on purpose — `anchor`/`anchorId` put it where the destructive action happened so it stays in viewport (Rule 8); a portal would have to undo that situationally. More importantly, dialogs are `aria-modal="true"` with `useFocusTrap`: a toast rendered above the modal but outside it cannot be tabbed to and is not announced, so an undo toast there would show an action nobody can take — the dead end UniversalDesign.md rules out ("nothing reachable that does nothing"). Feedback that looks available but isn't is worse than the status quo.

**So the dialog owns its feedback** — the pattern `ReplaceRecipeDialog` (`replaceError`), `CopyPasteDialog` (`copied` + its own status region) and this dialog's own `copyError` already follow (Rule 1). One slot per dialog, sitting where the eye lands on the way to the buttons: under the Gist ID field in the active step, under the token fields in the setup step.

**Both ends of an action share one region** (Rule 3). A copy that succeeded and a copy that failed are one concern; the success reuses the amber of `UndoToast`, the failure the red of the dialog's existing error box, so the message looks like the toast it replaces. A fresh `notice` also replaces a standing background sync error — it answers the click the user just made, which is what the old `copyError ?? syncStatus` precedence said too.

**Live region** per UniversalDesign.md: one permanent `<p className="sr-only" role="status">` at the foot of the dialog panel, outside the step switch so it is never created in the same render that first fills it, derived while rendering rather than pushed on a transition. The visible block deliberately carries no `role` of its own — the `role="alert"` that used to sit on `fieldError` would now announce the same text twice.

## Details

`fieldError` (empty token / empty Gist ID) is folded into the same slot rather than kept beside it: both it and the API errors block the same two buttons, so they are one concern and one region. The empty-field messages therefore move from directly under the inputs to just above the buttons, and gain the tinted box the API errors already had.

No new translation keys — `sync.gistIdCopied`, the four `sync.error*` and `copyPaste.copyFailed` all already exist in all four languages. No new colour pairings: `text-warning-text` on `bg-warning/10` is what this dialog's own security-warning box uses, `text-danger-text` on `bg-danger/10` what its error box used.

Out of scope, noted for later: a timed toast raised in the *background* (sync pull, storage error) while any dialog is open can still expire unseen. That needs a modal-open signal in `useFocusTrap` to hold the dismiss timer, and is a separate change.

## Testing

`npm run lint` and `npm run build` pass. Driven in Chromium against the dev server, light and dark:

- Setup step, empty token → "Please enter a token." visible in the slot and read back from the dialog's `role="status"` region.
- Setup step, bogus token + Gist ID → the GitHub error surfaces in the same slot instead of vanishing behind the backdrop.
- Active step, Copy Gist ID → "Gist ID copied to clipboard" in the slot and in the region; clipboard verified to hold the ID.

Not run: a real Gist round-trip against GitHub (no token here), and the clipboard-denied branch, which is unchanged apart from where its message is stored.

---

- [x] New strings added to all four languages (en, de, es, fr) — none added; every key reused already exists in all four
- [x] New controls: focus visible, reachable by keyboard, state not carried by colour alone — no new controls; the notice is non-interactive, carries its meaning in words, and is announced through a `role="status"` region. No new motion.
- [x] New panels are collapsible, state persisted to localStorage — n/a, no new panel
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — 1.16.1

---
_Generated by [Claude Code](https://claude.ai/code/session_014eDpbH9FQncE9ZGeg5K957)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feedback in the Gist synchronization dialog by displaying errors and status messages directly within the dialog.
  * Added clearer feedback for setup, connection, synchronization, and clipboard actions.
  * Consolidated messages into a single accessible status area for screen readers.

* **Chores**
  * Updated the application version to 1.16.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->