### PR TITLE
chore: add SessionStart hook installing npm dependencies on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Installs npm dependencies so lint and build work in Claude Code on the web,
+# where every session starts from a fresh clone without node_modules.
+set -euo pipefail
+
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+cd "${CLAUDE_PROJECT_DIR:-"$(dirname "$0")/../.."}"
+
+# npm writes node_modules/.package-lock.json at the end of every install. Is the
+# marker newer than the lockfile, the dependencies are up to date.
+if [ ! -e node_modules/.package-lock.json ] || [ ! node_modules/.package-lock.json -nt package-lock.json ]; then
+  # A SessionStart hook's stdout is added to the session context; npm's install
+  # log belongs in the hook output instead.
+  npm ci --no-audit --no-fund >&2
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -7,9 +7,23 @@ set -euo pipefail
 cd "${CLAUDE_PROJECT_DIR:-"$(dirname "$0")/../.."}"
 
 # npm writes node_modules/.package-lock.json at the end of every install. Is the
-# marker newer than the lockfile, the dependencies are up to date.
-if [ ! -e node_modules/.package-lock.json ] || [ ! node_modules/.package-lock.json -nt package-lock.json ]; then
-  # A SessionStart hook's stdout is added to the session context; npm's install
-  # log belongs in the hook output instead.
-  npm ci --no-audit --no-fund >&2
+# marker newer than both manifests, the dependencies are up to date. package.json
+# is checked too: on its own it means the two have drifted apart, which npm ci
+# refuses to install — better to surface that here than at the first build.
+if [ ! -e node_modules/.package-lock.json ] \
+  || [ ! node_modules/.package-lock.json -nt package-lock.json ] \
+  || [ ! node_modules/.package-lock.json -nt package.json ]; then
+  # A SessionStart hook's stdout is added to the session context, so npm's
+  # progress line goes to stderr and the success path stays silent.
+  if ! npm ci --no-audit --no-fund >&2; then
+    # A hook that exits 0 has its stderr sent to the debug log only, and any
+    # other non-zero code surfaces just the first line of it — whichever line
+    # npm happened to print first, not the one that explains the failure.
+    # SessionStart cannot block, so exit 2 is the one code that shows this to
+    # the user; the copy on stdout is what tells the agent.
+    failed="session-start hook: npm ci failed, dependencies are NOT installed. Run 'npm ci' before lint or build."
+    echo "$failed"
+    echo "$failed" >&2
+    exit 2
+  fi
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+            "command": "\"${CLAUDE_PROJECT_DIR}\"/.claude/hooks/session-start.sh"
           }
         ]
       }


### PR DESCRIPTION
## What

Claude Code on the web starts every session from a fresh clone, with no `node_modules` on disk. Until dependencies are installed, neither of the two checks `ci.yml` runs — `npm run lint` and `npm run build` — works, so an agent session either fails its first check or spends its opening move on an install. This adds a `SessionStart` hook that does that install up front.

The hook exits immediately unless `CLAUDE_CODE_REMOTE=true`, so local clones are untouched.

## Details

`.claude/settings.json` already existed for `enabledPlugins`; the `hooks` block is merged into it rather than replacing it.

Three decisions worth recording, since none is visible from the diff alone:

**A failed install exits 2, and says so on both streams.** This is the part that took two passes to get right, so the reasoning is worth keeping. Per the [hooks docs](https://code.claude.com/docs/en/hooks): stderr from a hook that exits 0 "goes to the debug log only, never the transcript, and Claude never sees it", and a non-zero exit without JSON on stdout surfaces only the *first* line of stderr. On a real failure that first line is whatever npm printed first — a forced `npm ci` failure here led with `npm error code EUSAGE`, which names no cause. Under `set -e` the original draft would therefore have aborted a broken install completely silently, leaving a session whose lint and build fail for no visible reason. `SessionStart` **cannot block** (docs: "Can block? No — Shows stderr to user only"), so exit 2 is the one code that surfaces the message without any risk of stalling startup. The same line goes to stdout, which `SessionStart` adds to the session context, so the agent knows not to trust `node_modules`.

**The install is guarded by an mtime check, and uses `npm ci`.** npm writes `node_modules/.package-lock.json` at the end of every install, so a marker newer than both manifests means the tree is current. Web containers cache their state after the hook completes, so on a warm container the hook does nothing and costs ~4 ms; the guard is what makes `npm ci` affordable there. `npm ci` in turn is what keeps `package-lock.json` from being rewritten mid-session, which would surface as a dirty working tree in every session that never touched dependencies. `package.json` is checked alongside the lockfile: newer on its own, the two have drifted apart, which `npm ci` refuses to install — better surfaced at session start than at the first build.

**npm's output goes to stderr.** `SessionStart` stdout becomes agent context, so the success path stays silent. This is tidiness, not a fix — measured, `npm ci` puts only 26 bytes on stdout (`added 176 packages in 5s`); its deprecation warnings already go to stderr on their own.

One review suggestion was **declined**: adding `"matcher": "startup|resume"` so the hook skips `clear`, `compact` and `fork`. The stated cost it avoids — session latency on compaction — is ~4 ms, because the freshness guard already makes those runs a no-op. Left unmatched, a `/clear` after pulling a branch with new dependencies re-syncs `node_modules` on its own, which is worth more than the 4 ms.

No app code, prompts, network targets or persisted state are touched.

## Testing

Ran against a container with `node_modules` removed between cases.

| Case | Result |
| --- | --- |
| Cold run, `CLAUDE_CODE_REMOTE=true` | installs, 7.1 s |
| Warm re-run | no-op, 0.004 s |
| Bytes on stdout, warm | 0 |
| Bytes on stdout, cold install | 0 (26 before the `>&2` redirect) |
| Without `CLAUDE_CODE_REMOTE` | no-op, exit 0 |
| `touch package-lock.json`, re-run | reinstalls |
| `touch package.json`, re-run | reinstalls |
| Forced failure (lockfile pinned to a nonexistent version) | **exit 2**, message on stdout *and* stderr; first stderr line without the handler was `npm error code EUSAGE` |
| Hook invoked from a path containing spaces | exit 0, installs |

`npm run lint` (via `npx eslint src/App.tsx`) and `npm run build` both pass afterwards, and the working tree is clean — `package-lock.json` is not rewritten. The build prints its pre-existing >500 kB chunk-size advisory; it is a warning, not an error, and is unchanged by this PR.

No test suite exists in this repo — there is no `test` script and no test framework in `package.json` — so lint and build are the whole check surface, and the hook is scoped to those.

---

- [x] New strings added to all four languages (en, de, es, fr) — accessible names included — *n/a, no user-facing strings*
- [x] New controls: focus visible, reachable by keyboard, state not carried by colour alone — and new motion checked under `prefers-reduced-motion` — *n/a, no UI*
- [x] New panels are collapsible, state persisted to localStorage — *n/a, no UI*
- [x] `npm run lint` and `npm run build` pass
- [x] Version bumped in `package.json`, `package-lock.json` and `AGENTS.md` — **deliberately not.** This changes repository tooling only; nothing in the deployed app differs, so there is no release to cut.